### PR TITLE
pretty_location plugin support for nesting resources in the resource …

### DIFF
--- a/lib/shrine/plugins/pretty_location.rb
+++ b/lib/shrine/plugins/pretty_location.rb
@@ -22,16 +22,32 @@ class Shrine
     #
     #     plugin :pretty_location, namespace: "/"
     #     # "blog/user/.../493g82jf23.jpg"
+    #
+    # A resource owner could be specified via ':owner' option.
+    # Then all the resources would be included into owner's folder.
+    #
+    # When the owner is a direct association, i.e. the ':blog' model
+    # contains the ':user_id':
+    #
+    #     plugin :pretty_location, namespace: "_", owner: "User"
+    #     # "user/1/blog_user/.../493g82jf23.jpg"
+    #
+    # Also, when the owner is a polymorphic association, i.e. the ':blog' model
+    # contains the ':owner_type', whic may be 'User', and the ':owner_id'
+    #
+    #     plugin :pretty_location, namespace: "_", owner: "Owner"
+    #     # "user/1/blog_user/.../493g82jf23.jpg"
     module PrettyLocation
       def self.configure(uploader, opts = {})
         uploader.opts[:pretty_location_namespace] = opts.fetch(:namespace, uploader.opts[:pretty_location_namespace])
+        uploader.opts[:pretty_location_owner] = opts.fetch(:owner, uploader.opts[:pretty_location_owner])
       end
 
       module InstanceMethods
-        def generate_location(io, context)
-          if context[:record]
-            type = class_location(context[:record].class) if context[:record].class.name
-            id   = context[:record].id if context[:record].respond_to?(:id)
+        def generate_location(_io, context)
+          if @record = context[:record]
+            type = type_string
+            id   = record.id if record.respond_to?(:id)
           end
           name = context[:name]
 
@@ -44,6 +60,17 @@ class Shrine
 
         private
 
+        attr_reader :owner, :record
+
+        def type_string
+          if @owner = opts[:pretty_location_owner]
+            owner.downcase!
+            str = owner_class_and_id_string
+          end
+
+          (str || '') << class_location(record.class) if record.class.name
+        end
+
         def class_location(klass)
           parts = klass.name.downcase.split("::")
           if separator = opts[:pretty_location_namespace]
@@ -51,6 +78,20 @@ class Shrine
           else
             parts.last
           end
+        end
+
+        def owner_class_and_id_string
+          # First the polymorphic association should be checked, because
+          # the record will respond to "#{owner}_id" in both cases
+          if record.respond_to?("#{owner}_type")
+            owner_string = record.__send__("#{owner}_type")
+            owner_id = record.__send__("#{owner}_id".to_sym)
+          elsif record.respond_to?("#{owner}_id")
+            owner_string = owner
+            owner_id = record.__send__("#{owner}_id".to_sym)
+          end
+          str = "#{owner_string.downcase}/" if owner_string
+          (str || '') << "#{owner_id}/" if owner_id
         end
       end
     end

--- a/test/plugin/pretty_location_test.rb
+++ b/test/plugin/pretty_location_test.rb
@@ -31,4 +31,16 @@ describe Shrine::Plugins::PrettyLocation do
     uploaded_file = @uploader.upload(fakeio, record: NameSpaced::OpenStruct.new(id: 123), name: :avatar)
     assert_match %r{^namespaced_openstruct/123/avatar/[\w-]+$}, uploaded_file.id
   end
+
+  it "includes owner and owner id when owner is a direct association" do
+    @uploader.class.plugin :pretty_location, namespace: "_", owner: 'User'
+    uploaded_file = @uploader.upload(fakeio, record: NameSpaced::OpenStruct.new(id: 123, user_id: 1), name: :avatar)
+    assert_match %r{^user/1/namespaced_openstruct/123/avatar/[\w-]+$}, uploaded_file.id
+  end
+
+  it "includes owner and owner id when owner is a polymorphic association" do
+    @uploader.class.plugin :pretty_location, namespace: "_", owner: 'Owner'
+    uploaded_file = @uploader.upload(fakeio, record: NameSpaced::OpenStruct.new(id: 123, owner_type: 'User', owner_id: 1), name: :avatar)
+    assert_match %r{^user/1/namespaced_openstruct/123/avatar/[\w-]+$}, uploaded_file.id
+  end
 end


### PR DESCRIPTION
…owner's folder (directly or polymorphic associated owner).

A resource owner could be specified via ':owner' option.
Then all the resources would be included into owner's folder.

When the owner is a direct association, i.e. the ':blog' model
contains the ':user_id':

```ruby
    plugin :pretty_location, namespace: "_", owner: "User"
    # "user/1/blog_user/.../493g82jf23.jpg"
```

Also, when the owner is a polymorphic association, i.e. the ':blog' model
contains the ':owner_type', whic may be 'User', and the ':owner_id'

```ruby
     plugin :pretty_location, namespace: "_", owner: "Owner"
     # "user/1/blog_user/.../493g82jf23.jpg"
```
