### PR TITLE
Remove broken article link from homepage

### DIFF
--- a/www/_data/external.yml
+++ b/www/_data/external.yml
@@ -48,9 +48,6 @@
         name: Upload images using Shrine.rb and Dropzone.js
         url: https://codyeatworld.com/2017/04/18/rails-uploading-images-confidently-with-shrine-rb/
       -
-        name: A code readers guide to Shrine.rb
-        url: http://justletyourcodeglo.com/blog/2017/04/19/reading-shrine.html
-      -
         name: Background file uploads to S3 using Shrine
         url: http://elixirator.com/blog/2017/background-file-uploads-to-s3-using-shrine.html
       -


### PR DESCRIPTION
This link is dead.

The site is offline, the domain has expired, and the content has not been reposted elsewhere. 🙁