### PR TITLE
Sort metadata for download_identifier

### DIFF
--- a/lib/shrine/plugins/download_endpoint.rb
+++ b/lib/shrine/plugins/download_endpoint.rb
@@ -131,7 +131,7 @@ class Shrine
         # long.
         def download_identifier
           semantical_metadata = metadata.select { |name, _| %w[filename size mime_type].include?(name) }
-          download_serializer.dump(data.merge("metadata" => semantical_metadata))
+          download_serializer.dump(data.merge("metadata" => semantical_metadata.sort.to_h))
         end
 
         def download_serializer


### PR DESCRIPTION
Sorting the metadata values by key, so the download_identifier always looks the same regardless of the order of metadata fields. Fixes #261.