### PR TITLE
Add Fastimage MIME type analyzer

### DIFF
--- a/lib/shrine/plugins/determine_mime_type.rb
+++ b/lib/shrine/plugins/determine_mime_type.rb
@@ -20,6 +20,10 @@ class Shrine
     #   contents. It is installed by default on most operating systems, but the
     #   [Windows equivalent] needs to be installed separately.
     #
+    # :fastimage
+    # : Uses the [fastimage] gem to determine the MIME type from file contents.
+    #   Fastimage is optimized for speed over accuracy. Best used for image content.
+    #
     # :filemagic
     # : Uses the [ruby-filemagic] gem to determine the MIME type from file
     #   contents, using a similar MIME database as the `file` utility. Unlike
@@ -81,6 +85,7 @@ class Shrine
     # [marcel]: https://github.com/basecamp/marcel
     # [mime-types]: https://github.com/mime-types/ruby-mime-types
     # [mini_mime]: https://github.com/discourse/mini_mime
+    # [fastimage]: https://github.com/sdsykes/fastimage
     module DetermineMimeType
       def self.configure(uploader, opts = {})
         uploader.opts[:mime_type_analyzer] = opts.fetch(:analyzer, uploader.opts.fetch(:mime_type_analyzer, :file))
@@ -140,7 +145,7 @@ class Shrine
       end
 
       class MimeTypeAnalyzer
-        SUPPORTED_TOOLS = [:file, :filemagic, :mimemagic, :marcel, :mime_types, :mini_mime]
+        SUPPORTED_TOOLS = [:fastimage, :file, :filemagic, :mimemagic, :marcel, :mime_types, :mini_mime]
         MAGIC_NUMBER    = 256 * 1024
 
         def initialize(tool)
@@ -181,6 +186,13 @@ class Shrine
           raise Error, "The `file` command-line tool is not installed"
         end
 
+        def extract_with_fastimage(io)
+          require "fastimage"
+
+          mime_type = FastImage.type(io)
+          "image/#{mime_type}" if mime_type
+        end
+        
         def extract_with_filemagic(io)
           require "filemagic"
 

--- a/test/plugin/determine_mime_type_test.rb
+++ b/test/plugin/determine_mime_type_test.rb
@@ -8,7 +8,7 @@ describe Shrine::Plugins::DetermineMimeType do
     @uploader = uploader { plugin :determine_mime_type }
     @shrine = @uploader.class
   end
-
+  
   describe ":file analyzer" do
     before do
       @shrine.plugin :determine_mime_type, analyzer: :file
@@ -50,6 +50,24 @@ describe Shrine::Plugins::DetermineMimeType do
     end
   end
 
+  describe ":fastimage analyzer" do
+    before do
+      @shrine.plugin :determine_mime_type, analyzer: :fastimage
+    end
+
+    it "extracts MIME type of any IO" do
+      assert_equal "image/jpeg", @shrine.determine_mime_type(image)
+    end
+
+    it "returns nil for unidentified MIME types" do
+      assert_nil @shrine.determine_mime_type(fakeio("😃"))
+    end
+
+    it "returns nil for empty IOs" do
+      assert_nil @shrine.determine_mime_type(fakeio(""))
+    end
+  end
+  
   describe ":filemagic analyzer" do
     before do
       @shrine.plugin :determine_mime_type, analyzer: :filemagic


### PR DESCRIPTION
Fastimage is super fast.

Since I'm already using Fastimage for mime type detection in my uploader class, I figured I could also use it as an analyzer option with the `:determine_mime_type` plugin.

That way, I just have a single dependency for mime type detection. Also, since my app is just uploading image files, I'm trying to optimize my image processing pipeline to be as fast as possible and this helps shave a bit more time off the processing lifecycle.

Tests are passing and it's also working in development for me.