### PR TITLE
Install libvips and ImageMagick on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 
-sudo: false
+sudo: required
+dist: trusty
 
 rvm:
   - 2.1
@@ -13,6 +14,9 @@ rvm:
   - jruby-head
 
 before_install:
+  - sudo apt-get -qq update
+  - sudo apt-get install libvips libvips-dev
+  - sudo apt-get install imagemagick libmagickcore-dev libmagickwand-dev
   - gem install bundler
 
 matrix:


### PR DESCRIPTION
This is required for the new `:mini_magick` and `:ruby_vips` dimensions analyzers.