### PR TITLE
Update external.yml

### DIFF
--- a/www/_data/external.yml
+++ b/www/_data/external.yml
@@ -130,7 +130,7 @@
         name: shrine-google_cloud_storage
         url: https://github.com/renchap/shrine-google_cloud_storage
       -
-        name: shrine-google_drive_storage
+        name: shrine-gdrive_storage
         url: https://github.com/edwardsharp/shrine-gdrive_storage
       -
         name: shrine-gridfs

--- a/www/_data/external.yml
+++ b/www/_data/external.yml
@@ -131,7 +131,7 @@
         url: https://github.com/renchap/shrine-google_cloud_storage
       -
         name: shrine-google_drive_storage
-        url: https://github.com/verynear/shrine-google_drive_storage
+        url: https://github.com/edwardsharp/shrine-gdrive_storage
       -
         name: shrine-gridfs
         url: https://github.com/shrinerb/shrine-gridfs


### PR DESCRIPTION
i forked and fixed up the existing Google Drive storage gem (verynear/shrine-google_drive_storage) to use a Google API Service Account. 

it's passing the shrine lint tests! 