### PR TITLE
Improve the filesize validation error message

### DIFF
--- a/lib/shrine/plugins/validation_helpers.rb
+++ b/lib/shrine/plugins/validation_helpers.rb
@@ -63,7 +63,7 @@ class Shrine
       PRETTY_FILESIZE = lambda do |num|
         return "0.0 B" if num == 0
 
-        exp = (Math.log10(num) / Math.log10(1024)).to_i
+        exp = Math.log(num, 1024).floor
         max_exp = FILESIZE_UNITS.length - 1
         exp = max_exp if exp > max_exp
         "%.1f %s" % [num.to_f / 1024 ** exp, FILESIZE_UNITS[exp]]

--- a/lib/shrine/plugins/validation_helpers.rb
+++ b/lib/shrine/plugins/validation_helpers.rb
@@ -44,8 +44,8 @@ class Shrine
       end
 
       DEFAULT_MESSAGES = {
-        max_size: ->(max) { "is too large (max is #{max.to_f/1024/1024} MB)" },
-        min_size: ->(min) { "is too small (min is #{min.to_f/1024/1024} MB)" },
+        max_size: ->(max) { "is too large (max is #{PRETTY_FILESIZE.call(max)})" },
+        min_size: ->(min) { "is too small (min is #{PRETTY_FILESIZE.call(min)})" },
         max_width: ->(max) { "is too wide (max is #{max} px)" },
         min_width: ->(min) { "is too narrow (min is #{min} px)" },
         max_height: ->(max) { "is too tall (max is #{max} px)" },
@@ -55,6 +55,19 @@ class Shrine
         extension_inclusion: ->(list) { "isn't of allowed format (allowed formats: #{list.join(", ")})" },
         extension_exclusion: ->(list) { "is of forbidden format" },
       }
+
+      FILESIZE_UNITS = ["B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"].freeze
+
+      # Returns filesize in a human readable format with units.
+      # Uses the binary JEDEC unit system, i.e. 1.0 KB = 1024 bytes
+      PRETTY_FILESIZE = lambda do |num|
+        return "0.0 B" if num == 0
+
+        exp = (Math.log10(num) / Math.log10(1024)).to_i
+        max_exp = FILESIZE_UNITS.length - 1
+        exp = max_exp if exp > max_exp
+        "%.1f %s" % [num.to_f / 1024 ** exp, FILESIZE_UNITS[exp]]
+      end
 
       module AttacherClassMethods
         def default_validation_messages

--- a/lib/shrine/plugins/validation_helpers.rb
+++ b/lib/shrine/plugins/validation_helpers.rb
@@ -60,13 +60,13 @@ class Shrine
 
       # Returns filesize in a human readable format with units.
       # Uses the binary JEDEC unit system, i.e. 1.0 KB = 1024 bytes
-      PRETTY_FILESIZE = lambda do |num|
-        return "0.0 B" if num == 0
+      PRETTY_FILESIZE = lambda do |bytes|
+        return "0.0 B" if bytes == 0
 
-        exp = Math.log(num, 1024).floor
+        exp = Math.log(bytes, 1024).floor
         max_exp = FILESIZE_UNITS.length - 1
         exp = max_exp if exp > max_exp
-        "%.1f %s" % [num.to_f / 1024 ** exp, FILESIZE_UNITS[exp]]
+        "%.1f %s" % [bytes.to_f / 1024 ** exp, FILESIZE_UNITS[exp]]
       end
 
       module AttacherClassMethods

--- a/test/plugin/validation_helpers_test.rb
+++ b/test/plugin/validation_helpers_test.rb
@@ -597,4 +597,28 @@ describe Shrine::Plugins::ValidationHelpers do
       assert_equal 1, @attacher.errors.size
     end
   end
+
+  describe "#PRETTY_FILESIZE" do
+    it "returns 0.0 B if size = 0" do
+      assert_equal "0.0 B", Shrine::Plugins::ValidationHelpers::PRETTY_FILESIZE.call(0)
+    end
+
+    it "returns correct units from bytes to yoltabytes" do
+      units = ["B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"]
+
+      units.each_with_index do |unit, index|
+        size = 1024 ** index
+        assert_equal "#{1}.0 #{unit}", Shrine::Plugins::ValidationHelpers::PRETTY_FILESIZE.call(size)
+      end
+
+      size = 1024 ** 10
+      assert_equal "1048576.0 YB", Shrine::Plugins::ValidationHelpers::PRETTY_FILESIZE.call(size)
+
+      units.each_with_index do |unit, index|
+        next if index == 0
+        size = 1023 * 1024 ** index
+        assert_equal "1023.0 #{unit}", Shrine::Plugins::ValidationHelpers::PRETTY_FILESIZE.call(size)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Changes the filesize in the error message to a more human readable version with units upto YB. Filesize is reported in the binary JEDEC unit system where 1.0 KB = 1024 bytes.