### PR TITLE
Raise error when mime type plugin opens non-existent file

### DIFF
--- a/lib/shrine/plugins/determine_mime_type.rb
+++ b/lib/shrine/plugins/determine_mime_type.rb
@@ -177,7 +177,7 @@ class Shrine
 
             status = thread.value
 
-            raise Error, stderr.read unless status.success?
+            raise Error, stderr.read unless !status.nil? && status.success?
             $stderr.print(stderr.read)
 
             stdout.read.strip

--- a/test/plugin/determine_mime_type_test.rb
+++ b/test/plugin/determine_mime_type_test.rb
@@ -41,6 +41,11 @@ describe Shrine::Plugins::DetermineMimeType do
       assert_raises(Shrine::Error) { @shrine.determine_mime_type(image) }
     end
 
+    it "raises error if file command thread.value is nil" do
+      Open3.expects(:popen3).yields(StringIO.new, StringIO.new, StringIO.new, Thread.new {})
+      assert_raises(Shrine::Error) { @shrine.determine_mime_type(fakeio("d")) }
+    end
+
     it "fowards any warnings to stderr" do
       assert_output(nil, "") { @shrine.determine_mime_type(image) }
 


### PR DESCRIPTION
Closes #279.

Not sure how to test for this edge case. Any ideas?