### PR TITLE
For discussion: experiment using optimistic locking to avoid race condition

### DIFF
--- a/lib/shrine/plugins/backgrounding.rb
+++ b/lib/shrine/plugins/backgrounding.rb
@@ -263,6 +263,14 @@ class Shrine
 
         # Updates with the new file only if the attachment hasn't changed.
         def swap(new_file)
+          # This does what the `find_record` approach is supposed to do -- but reliably.
+          # By using the atomic_update method -- but swap isn't neccesarly only used in
+          # promotion, for instance it's in the recommended instructions for regenerating versions.
+          # Is this new implementation going to cause problems?
+          if self.respond_to?(:safe_update, true)
+            return safe_update(new_file)
+          end
+
           if self.class.respond_to?(:find_record)
             reloaded = self.class.find_record(record.class, record.id)
             return if reloaded.nil? || self.class.new(reloaded, name).read != read


### PR DESCRIPTION
This is not really proposed as being possibly ready for merge, it's sometimes just easier to talk starting from some code, instead of purely abstract discussion. I also did this as part of getting more familiar with shrine's internal implementation, and because concurrent race conditions are likely to be even more of a problem (and more complicated to solve) when dealing with 'derivatives' possibilities. 

This uses an "optimistic locking" approach on promotion with backgrounding plugin, replacing the logic there before that meant to avoid the race condition but did not do so completely -- right now only with an ActiveRecord implementation -- but it does not use ActiveRecord's built-in optimistic locking approach, instead it locks on the shrine data column, while only updating the shrine data column. 

One of the nice things about that approach is that, unlike built-in optimistic locking, if someone else has updated the record, but only _other_ columns, it will sucessfully not conflict. 

Because of the limitations on API's available in AR, the consequence of this is you don't get AR callbacks called -- so no AR callbacks would be called in promotion phase. Or in any manual uses of the `swap` method, as for instance recommended in the [regenerating versions](https://github.com/shrinerb/shrine/blob/master/doc/regenerating_versions.md#reprocessing-a-single-version) doc.  It's possible that if we were to go ahead with this approach, we'd have to make sure there were easy ways to use built in before/after/around promotion/swap/update hooks that could serve as a substitute for the missing AR ones (which might be difficult to make them fully capable with access to deltas). 

That may be a deal-breaker already. It does _not_ cause any tests to fail, but that may be considered a test bug/hole.  When I tried overriding `update` directly instead of `swap` to use this approach, it did cause test failures.  It's not actually clear to me whether `update` or `swap` would be the "right" thing to override, I am unclear on what the difference in semantics between the two methods is supposed to be. 

### Other approaches

If this whole approach is not gonna work out (I'm not sure), and this race condition is actually in need of fixing (I'm not sure how serious it is; I was mostly investigating cause it will get more serious with 'derivatives' and I wanted to start playing with something simpler), other approaches could include:

1. Pessimistic locking.  Personally not a fan, the performance characteristics and deadlock potentials of pessimistic locking are something I find confusing and hard to deal with. 

2. For ActiveRecord, suggest that if someone cares about the race condition, they use AR's own optimistic locking feature on the relevant model -- but then shrine code could rescue the `ActiveRecord:: StaleObjectError` and do appropriate things in the rescue (the appropriate thing may differ in this simple case (where it's probably just silently abandon) and in the hypothetical derivatives case (where it would want to merge changes and try again). 

3. Use DB transactions with explicit raised [isolation levels](https://www.postgresql.org/docs/9.1/static/transaction-iso.html).  It is possible to do that in AR, should be in Sequel. Hypothetically, if I am understanding the documentation right, postgres with "repeatable read" for this use case will result in functionality almost identical to optimistic locking -- more like AR optimistic locking where any change to any column of the model will cause an error.  I'm not totally sure what exception AR will raise in that case, or if it's consistent from db to db. It's hard to wrap your head around transaction isolation levels, and the semantics can differ between dbs (although there is an SQL spec for it, not always followed).  One reason I like optimistic locking is cause I pretty much understand it's semantics and performance characteristics, whereas features like transaction isolation and pessimistic locking seem much more like dark arts. 