### PR TITLE
Remove wrong method comment

### DIFF
--- a/lib/shrine/plugins/versions.rb
+++ b/lib/shrine/plugins/versions.rb
@@ -234,8 +234,7 @@ class Shrine
           end
         end
 
-        # Deletes each file individually, but uses S3's multi delete
-        # capabilities.
+        # Deletes each file individually
         def _delete(uploaded_file, context)
           if (hash = uploaded_file).is_a?(Hash)
             hash.each do |name, value|


### PR DESCRIPTION
This method does NOT, ever, "uses S3's multi delete capabilities."

I think? Am I wrong?

Ah, maybe the _override_ in the deprecated multi-delete plugin WOULD do that -- but the comment doesn't belong here then. It could be here as "overridden by multi_delete to...", but if it's deprecated anyway, maybe no need to mention that.