### PR TITLE
Add a code hint for Roda requirement to download endpoint docs

### DIFF
--- a/lib/shrine/plugins/download_endpoint.rb
+++ b/lib/shrine/plugins/download_endpoint.rb
@@ -12,6 +12,9 @@ class Shrine
     # from your storage isn't accessible over URL (e.g. database storages) or
     # if you want to authenticate your downloads. It requires the [Roda] gem.
     #
+    #     # Gemfile
+    #     gem 'roda' # for mounting Shrine's download endpoint
+    #
     # You can configure the plugin with the path prefix which the endpoint will
     # be mounted on.
     #


### PR DESCRIPTION
Hi Janko, thanks for this amazing gem and ecosystem! 

I've just run into a bit of trouble with less helpful looking error messages (though the end of the stacktrace points to the main reason) when adding the download endpoint plugin without having added the `roda` gem to the bundle first. Please decide if you want to add this hint, otherwise you can just close the PR.