### PR TITLE
Fail when file command returned error in stdout

### DIFF
--- a/lib/shrine/plugins/determine_mime_type.rb
+++ b/lib/shrine/plugins/determine_mime_type.rb
@@ -179,9 +179,14 @@ class Shrine
 
             raise Error, "file command failed to spawn: #{stderr.read}" if status.nil?
             raise Error, "file command failed: #{stderr.read}" unless status.success?
+
             $stderr.print(stderr.read)
 
-            stdout.read.strip
+            output = stdout.read.strip
+
+            raise Error, "file command failed: #{output}" if output.include?("cannot open")
+
+            output
           end
         rescue Errno::ENOENT
           raise Error, "file command-line tool is not installed"

--- a/test/plugin/determine_mime_type_test.rb
+++ b/test/plugin/determine_mime_type_test.rb
@@ -49,6 +49,14 @@ describe Shrine::Plugins::DetermineMimeType do
       assert_match "file command failed to spawn: ", exception.message
     end
 
+    it "raises error if file command couldn't open file" do
+      result = Open3.popen3("file", "--version")
+      result[1] = StringIO.new("cannot open: No such file or directory") # stdout
+      Open3.expects(:popen3).yields(result)
+      exception = assert_raises(Shrine::Error) { @shrine.determine_mime_type(fakeio("d")) }
+      assert_match "file command failed: cannot open: No such file or directory", exception.message
+    end
+
     it "fowards any warnings to stderr" do
       assert_output(nil, "") { @shrine.determine_mime_type(image) }
 


### PR DESCRIPTION
It appears that the file command can also fail with a successful exit status, in which case the error is returned in stdout. This commit handles that.

So far the only error we know about is

```
cannot open: No such file or directory
```

It's very odd this error happens, because Shrine passes file content to the standard input, it doesn't use a path on disk, so I don't know how this error could happen.

See https://github.com/shrinerb/shrine/issues/303