### PR TITLE
Force filename encoding to utf-8 in rack_file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## HEAD
 
+* Specify UTF-8 charset in `Content-Type` response header in `upload_endpoint` plugin (@janko-m)
+
+* Force UTF-8 encoding on filenames coming from Rack's multipart request params in `rack_file` plugin (@janko-m)
+
 * Allow `:host` in `S3#url` to specify a host URL with an additional path prefix (@janko-m)
 
 * Revert adding bucket name to URL path in `S3#url` when `:host` is used with `:force_path_style` (@janko-m)

--- a/lib/shrine/plugins/rack_file.rb
+++ b/lib/shrine/plugins/rack_file.rb
@@ -47,6 +47,13 @@ class Shrine
       module ClassMethods
         # Accepts a Rack uploaded file hash and wraps it in an IO object.
         def rack_file(hash)
+          if hash[:filename]
+            # Rack returns filename binary encoded, so we change it to utf-8
+            hash = hash.merge(
+              filename: hash[:filename].dup.force_encoding(Encoding::UTF_8)
+            )
+          end
+
           UploadedFile.new(hash)
         end
       end

--- a/lib/shrine/plugins/upload_endpoint.rb
+++ b/lib/shrine/plugins/upload_endpoint.rb
@@ -94,7 +94,7 @@ class Shrine
     # You can also customize the upload itself via the `:upload` option:
     #
     #     plugin :upload_endpoint, upload: -> (io, context, request) do
-    #       # perform uploading and return the Shrine::UploadedFile
+    #       Shrine.new(:cache).upload(io, context)
     #     end
     #
     # ## Response
@@ -150,6 +150,9 @@ class Shrine
       # calls `#upload` with the uploaded file, and returns the uploaded file
       # information in JSON format.
       class App
+        CONTENT_TYPE_JSON = "application/json; charset=utf-8"
+        CONTENT_TYPE_TEXT = "text/plain"
+
         # Writes given options to instance variables.
         def initialize(options)
           options.each do |name, value|
@@ -233,7 +236,7 @@ class Shrine
           if @rack_response
             @rack_response.call(object, request)
           else
-            [200, {"Content-Type" => "application/json"}, [object.to_json]]
+            [200, {"Content-Type" => CONTENT_TYPE_JSON}, [object.to_json]]
           end
         end
 
@@ -247,7 +250,7 @@ class Shrine
 
         # Used for early returning an error response.
         def error!(status, message)
-          throw :halt, [status, {"Content-Type" => "text/plain"}, [message]]
+          throw :halt, [status, {"Content-Type" => CONTENT_TYPE_TEXT}, [message]]
         end
 
         # Returns the uploader around the specified storage.

--- a/shrine.gemspec
+++ b/shrine.gemspec
@@ -46,6 +46,7 @@ direct uploads for fully asynchronous user experience.
   gem.add_development_dependency "ruby-vips", "~> 2.0" unless ENV["CI"]
   gem.add_development_dependency "aws-sdk-s3", "~> 1.16"
   gem.add_development_dependency "aws-sdk-core", "~> 3.23"
+  gem.add_development_dependency "http-form_data", "~> 2.0"
 
   unless RUBY_ENGINE == "jruby" || ENV["CI"]
     gem.add_development_dependency "ruby-filemagic", "~> 0.7"

--- a/test/plugin/rack_file_test.rb
+++ b/test/plugin/rack_file_test.rb
@@ -64,6 +64,15 @@ describe Shrine::Plugins::RackFile do
     assert_equal "image/jpeg", rack_file.content_type
   end
 
+  it "converts filename from binary encoding to utf-8" do
+    @rack_hash[:filename] = "über_pdf_with_1337%_leetness.pdf".b
+
+    rack_file = @shrine.rack_file(@rack_hash)
+
+    assert_equal Encoding::UTF_8, rack_file.original_filename.encoding
+    assert_equal Encoding::BINARY, @rack_hash[:filename].encoding
+  end
+
   it "supports attaching Rack files directly" do
     @attacher.assign(@rack_hash)
 


### PR DESCRIPTION
Rack's multipart parser will return filename in binary encoding if it has any non-ascii characters. When this file is converted to an IO-like object via `Shrine.rack_file` and uploaded via `Shrine#upload`, the filename will be copied to the `Shrine::UploadedFile` object.

However, when we attempt to serialize a `Shrine::UploadedFile` object with a binary encoded filename into JSON, Ruby's JSON parser will raise an exception because it requires all strings to be in UTF-8 encoding.

To address this, we force the filename encoding to UTF-8 in `Shrine.rack_file`. This is similar to what Rails does in `ActionDispatch::Http::UploadedFile`.

Fixes #307