### PR TITLE
suggest passing in context to refresh_metadata!

### DIFF
--- a/doc/metadata.md
+++ b/doc/metadata.md
@@ -220,7 +220,7 @@ class ImageUploader < Shrine
 
   # this will be called in the background if using backgrounding plugin
   process(:store) do |io, context|
-    io.refresh_metadata! # extracts metadata and updates `io.metadata`
+    io.refresh_metadata!(context) # extracts metadata and updates `io.metadata`
     io
   end
 end


### PR DESCRIPTION
When messing with possibilities of refresh_metadata!,I didn't realize it could take a context param. 

Does it make sense to suggest in this example passing in the context, so the possible `add_metadata do |io, context|` invocations will still get a context very much like "normal"?