### PR TITLE
Use a guard raise cause for `bucket` argument in S3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## HEAD
+
+* Use a guard raise cause for `bucket` argument in S3 for an appropriate error message (@ardecvz)
+
 ## 2.13.0 (2018-11-04)
 
 * Specify UTF-8 charset in `Content-Type` response header in `presign_endpoint` plugin (@janko-m)

--- a/lib/shrine/storage/s3.rb
+++ b/lib/shrine/storage/s3.rb
@@ -250,6 +250,8 @@ class Shrine
       # [`Aws::S3::Client#initialize`]: http://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/S3/Client.html#initialize-instance_method
       # [configuring AWS SDK]: https://docs.aws.amazon.com/sdk-for-ruby/v3/developer-guide/setup-config.html
       def initialize(bucket:, prefix: nil, host: nil, upload_options: {}, multipart_threshold: {}, signer: nil, public: nil, **s3_options)
+        raise ArgumentError, "the :bucket option is nil" unless bucket
+
         Shrine.deprecation("The :host option to Shrine::Storage::S3#initialize is deprecated and will be removed in Shrine 3. Pass :host to S3#url instead, you can also use default_url_options plugin.") if host
         resource = Aws::S3::Resource.new(**s3_options)
 
@@ -259,7 +261,7 @@ class Shrine
         end
         multipart_threshold = { upload: 15*1024*1024, copy: 100*1024*1024 }.merge(multipart_threshold)
 
-        @bucket = resource.bucket(bucket) or fail(ArgumentError, "the :bucket option was nil")
+        @bucket = resource.bucket(bucket)
         @client = resource.client
         @prefix = prefix
         @host = host

--- a/test/s3_test.rb
+++ b/test/s3_test.rb
@@ -25,8 +25,9 @@ describe Shrine::Storage::S3 do
   end
 
   describe "#initialize" do
-    it "raises an error when :bucket is nil" do
-      assert_raises(ArgumentError) { s3(bucket: nil) }
+    it "raises an appropriate error when :bucket is nil" do
+      error = assert_raises(ArgumentError) { s3(bucket: nil) }
+      assert_match "the :bucket option is nil", error.message
     end
 
     deprecated "accepts :multipart_threshold as an Integer" do


### PR DESCRIPTION
Hi, Janko!

First of all, thank you for your a hard work on Shrine! It's a indispensable tool for complex upload workflows with a really sleek design.

Back to PR, I'd like to use a guard raise cause for bucket argument in S3 for an appropriate error message.

Before the change, it fails with a misleading error message mentioning
a missing `name` option (`missing required option :name`).

The raised error originated from S3 gem instead of Shrine.

It leads to a little confusion as a bucket is often configured with
an environment variable which is set by system administrators.
