### PR TITLE
Don't lookup attachment class on every attacher read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD
 
+* Don't lookup attachment class on every attacher read (@printercu)
+
 * Allow assigning a filename to the `DataFile` object in `Shrine.data_uri` (@janko-m)
 
 * Don't strip media type parameters for the `DataFile` object in `data_uri` plugin (@janko-m)


### PR DESCRIPTION
Hi!

I've changed `class_eval` to `define_method` for `*_attacher` methods, so it has access to attachment (and it's attacher) inside. This removes `ancestors.grep.find` to get attacher class dynamically.