### PR TITLE
provide opt to disable mime-type security warning

### DIFF
--- a/lib/shrine.rb
+++ b/lib/shrine.rb
@@ -295,7 +295,9 @@ class Shrine
         # Attempts to extract the MIME type from the IO object.
         def extract_mime_type(io)
           if io.respond_to?(:content_type) && io.content_type
-            warn "The \"mime_type\" Shrine metadata field will be set from the \"Content-Type\" request header, which might not hold the actual MIME type of the file. It is recommended to load the determine_mime_type plugin which determines MIME type from file content."
+            if opts[:mime_type_security_warning] != :suppress
+              warn "The \"mime_type\" Shrine metadata field will be set from the \"Content-Type\" request header, which might not hold the actual MIME type of the file. It is recommended to load the determine_mime_type plugin which determines MIME type from file content."
+            end
             io.content_type.split(";").first # exclude media type parameters
           end
         end

--- a/test/shrine_test.rb
+++ b/test/shrine_test.rb
@@ -172,7 +172,7 @@ describe Shrine do
   it "has #storage_key, #storage and #opts" do
     assert_equal :store, @uploader.storage_key
     assert_equal @shrine.storages[:store], @uploader.storage
-    assert_equal Hash.new, @uploader.opts
+    assert_kind_of Hash, @uploader.opts
   end
 
   describe "#upload" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -17,9 +17,8 @@ require "mocha/minitest"
 
 require "shrine"
 
-class Shrine
-  def warn(*); end # disable mime_type warnings
-end
+# disable mime_type warnings
+Shrine.opts[:mime_type_security_warning] = :suppress
 
 require "./test/support/generic_helper"
 require "./test/support/deprecated_helper"


### PR DESCRIPTION
Shrine.opts[:mime_type_security_warning] = :suppress

Used in shrine test env now instead of monkey patch that disabled all warnings