### PR TITLE
extract proper extension when id is a shrine-url with query params

### DIFF
--- a/lib/shrine/uploaded_file.rb
+++ b/lib/shrine/uploaded_file.rb
@@ -2,6 +2,7 @@
 
 require "json"
 require "tempfile"
+require "uri"
 
 class Shrine
   # Core class that represents a file uploaded to a storage.
@@ -58,6 +59,10 @@ class Shrine
       # from #original_filename.
       def extension
         result = File.extname(id)[1..-1] || File.extname(original_filename.to_s)[1..-1]
+        # for shrine-url use, id may be url with query params, strip em after ?
+        if result && result.index('?') && id =~ URI::regexp
+          result = result[0..result.index('?') - 1]
+        end
         result.downcase if result
       end
 

--- a/test/shrine_test.rb
+++ b/test/shrine_test.rb
@@ -352,6 +352,17 @@ describe Shrine do
       assert_match /^[\w-]+$/, location
     end
 
+    it "gets extension from shrine-url-style id with query params" do
+      uploaded_file = @shrine.uploaded_file("id" => "http://example.com/path.html?key=value", "storage" => "cache")
+      location = @uploader.generate_location(uploaded_file)
+      assert_match /\.html$/, location
+
+      uploaded_file = @shrine.uploaded_file("id" => "http://example.com/path?key=value", "storage" => "cache")
+      location = @uploader.generate_location(uploaded_file)
+      refute_match /key=value/, location
+      assert_match /^[\w-]+$/, location
+    end
+
     it "can access extracted metadata" do
       @uploader.instance_eval do
         def generate_location(io, context)

--- a/test/uploaded_file_test.rb
+++ b/test/uploaded_file_test.rb
@@ -124,6 +124,26 @@ describe Shrine::UploadedFile do
       uploaded_file = uploaded_file("metadata" => {"filename" => "foo.JPG"})
       assert_equal "jpg", uploaded_file.extension
     end
+
+    it "does not include query params from shrine-url ids in extension" do
+      uploaded_file =uploaded_file("id" => "http://example.com/path.html?key=value", "storage" => "cache")
+      assert_equal "html", uploaded_file.extension
+
+      uploaded_file = uploaded_file("id" => "http://example.com/path?key=value", "storage" => "cache")
+      assert_nil uploaded_file.extension
+    end
+
+    it "can still handle non-url extensions with question marks" do
+      uploaded_file = uploaded_file("id" => "foo.?xx")
+      assert_equal "?xx", uploaded_file.extension
+
+      uploaded_file = uploaded_file("id" => "foo.x?x")
+      assert_equal "x?x", uploaded_file.extension
+
+      uploaded_file = uploaded_file("id" => "foo.xx?")
+      assert_equal "xx?", uploaded_file.extension
+    end
+
   end
 
   describe "#size" do


### PR DESCRIPTION
This seems, to me too, a bit hacky the way it's a special purpose branch, but I couldn't think of a better way.  Didn't see any good way to put this in shrine-url, even though it only matters for shrine-url. 

Test against URI::Regexp to try and avoid messing up anything else (like an actual file with a question mark actually in it's extension?), but do it as last clause cause the earlier short-circuit checks are cheaper. 

Closes shrinerb/shrine-url#4