### PR TITLE
WIP sketch for discussion: Idempotent/reusable UploadedFile#download approach

### DIFF
--- a/lib/shrine/storage/s3.rb
+++ b/lib/shrine/storage/s3.rb
@@ -364,7 +364,6 @@ class Shrine
         options.merge!(upload_options)
 
         options[:content_disposition] = encode_content_disposition(options[:content_disposition]) if options[:content_disposition]
-
         if copyable?(io)
           copy(io, id, **options)
         else


### PR DESCRIPTION
This is _definitely_ not complete code, it's a sketch to have code to talk about instead of just words. 

## Use case/situation

I have an S3 cache and an S3 store, and am using direct uploads to S3. I am doing `refresh_metadata` at `store` action to get metadata on promotion (which I am also using backgrounding for). 

Let's say I have:

```ruby
add_metadata do |io, context|
  {
    md5: calculate_signature(io, :md5),
    sha1: calculate_signature(io, :sha1)
  }
end
```

This works great. calculating a signature of course does require the whole file. The first one will end up streaming the whole file, via `down`. The second one will end up using the `down` cached file, _not_ retrieving the whole stream from S3 again. Great, this is awesome. 

But now let's say I have another metadata block:

```ruby
add_metadata(:page_count) do |io, context|
  io.download do |file|
    PDF::Reader.new(file.path).page_count
  end
end
```

This will end up pulling all the bytes from S3 again, even though the `down` cache already had them. 

If I have _another_ `add_metadata` block which _also_ does `io.download`, it'll end up pulling all the bytes from S3 _again_.  (Why might I have this? Because they were written as decoupled metadata extraction components that shouldn't have to know about each other, or coordinate with each other. but yes, I _could_ always rewrite my metadata extraction to have only one `io.download` in it -- but maybe I wanna have re-usable metadata extraction routines shared between uploaders (in a gem?), the fact that they have to be coordinated complicates things). 

## The goal/approach

Is there a way to provide an "idempotent" `#download` that will cache and always re-use any previously downloaded bytes?

This would probably have to be in `UploadedFile#download` -- that's the only place that has state to cache and re-use. (It's also the only place that knows about any existing Down::ChunkedIO that may already have cached the file). 

If there's already a fully-cached Down::ChunkedIO, can we re-use these bytes on disk to give to the caller of `#download`? (Problems: Down::ChunkedIO doesn't really give us public/reliable API to see that we have a fully loaded cache, _or_ to get access to the bytes on disk. We use private API as a demo. It all does end up a bit too tightly coupled between `down` internal implementation and `UploadedFile#download`, alas). 

If there isn't a fully-cached Down::ChunkedIO -- we're just going to have to ask the storage to `download`, we can't really re-use the _partially_ cached Down::ChunkedIO. (Becuase storages, in particular S3,  have their reasons for using a different method to implement #download, that doesn't use `down`).  But can we cache and re-use these bytes, so if a _second_ caller calls `download`, they get the same bytes?  Yes, we can...

It does mean that we can't explicitly `close!` the Tempfile in question like `UploadedFile#download` did before -- the whole point is we want to leave it there so it can be re-used by a second `download` call. Since it's a TempFile, it should be removed by ruby when the obj is GC'd (when the UploadedFile obj itself is), which could be significant latency... but I _think_ it's effectively the way the UploadedFile's Down::ChunkedIO cache was getting cleaned up already anyway. 

There are a number of failing tests. I think _some_ of them are 'false' fails -- the tests were just reliant on internal implementation to pass, even though that internal implementation wasn't really relevant to public API. But some failing tests are probably real failing tests. 

If this approach makes sense at all (**and it may not**), perhaps we'd want to leave the existing `UploadedFile#download` alone, and provide a new `UploadedFile#idempotent_download` or `UploadedFile#download(idempotent: true)`. (Not really sure "idempotent" is the right word, maybe "reusable"). 

It's also very unclear to me how to write tests for this demonstrated new approach. :)  Also this new approach probably has some concurrency concerns (two threads call `#download` on same UploadedFile concurrently, the caching gets confused) -- which possibly could be handled just by putting the whole thing in a mutex. 

I am not really sure if anything even resembling this approach is feasible, but providing some actual code may make it easier to talk about, I was hoping. 