### PR TITLE
Remove Storage#download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## HEAD
 
+* Deprecate `Storage::S3#download` (@janko-m)
+
+* Stop using `Storage#download` in `UploadedFile#download` for peformance (@janko-m)
+
+* Remove `#download` from the Shrine storage specification (@janko-m)
+
 * Keep `context` argument in `#extract_metadata` optional after loading `add_metadata` plugin (@janko-m)
 
 * Include metadata key with `nil` value when `nil` is returned in `add_metadata` block (@janko-m)

--- a/doc/creating_storages.md
+++ b/doc/creating_storages.md
@@ -122,27 +122,6 @@ The storage can support additional options to customize how the file will be
 opened, `Shrine::UploadedFile#open` and `Shrine::UploadedFile#download` will
 forward any given options to `#open`.
 
-## Download
-
-`Shrine::UploadedFile#download` by default uses the `#open` storage method to
-stream file content to a Tempfile. However, if you would like to use your own
-custom way of downloading to a file, you can define `#download` on the storage
-and `Shrine::UploadedFile#download` will automatically call that instead.
-
-```rb
-class MyStorage
-  # ...
-  def download(id, **options)
-    # download the uploaded file to a Tempfile
-  end
-  # ...
-end
-```
-
-The storage can support additional options to customize how the file will be
-downloaded, `Shrine::UploadedFile#download` will forward any given options to
-`#download`.
-
 ## Url
 
 The `#url` storage method is called by `Shrine::UploadedFile#url`, it accepts a

--- a/doc/design.md
+++ b/doc/design.md
@@ -125,6 +125,7 @@ uploaded_file.size
 # storage methods
 uploaded_file.url
 uploaded_file.exists?
+uploaded_file.open
 uploaded_file.download
 uploaded_file.delete
 # ...

--- a/lib/shrine/storage/linter.rb
+++ b/lib/shrine/storage/linter.rb
@@ -38,7 +38,6 @@ class Shrine
       def call(io_factory = default_io_factory)
         storage.upload(io_factory.call, id = "foo".dup, {})
 
-        lint_download(id) if storage.respond_to?(:download)
         lint_open(id)
         lint_exists(id)
         lint_url(id)
@@ -57,12 +56,6 @@ class Shrine
         if storage.respond_to?(:presign)
           lint_presign(id)
         end
-      end
-
-      def lint_download(id)
-        downloaded = storage.download(id)
-        error :download, "doesn't return a Tempfile" if !downloaded.is_a?(Tempfile)
-        error :download, "returns an empty IO object" if downloaded.read.empty?
       end
 
       def lint_open(id)

--- a/lib/shrine/uploaded_file.rb
+++ b/lib/shrine/uploaded_file.rb
@@ -105,8 +105,7 @@ class Shrine
         end
       end
 
-      # Calls `#download` on the storage if the storage implements it,
-      # otherwise streams content into a newly created Tempfile.
+      # Streams content into a newly created Tempfile and returns it.
       #
       # If a block is given, the opened Tempfile object is yielded to the
       # block, and at the end of the block it's automatically closed and
@@ -122,13 +121,9 @@ class Shrine
       #
       #     uploaded_file.download { |tempfile| tempfile.read } # tempfile is deleted
       def download(*args)
-        if storage.respond_to?(:download)
-          tempfile = storage.download(id, *args)
-        else
-          tempfile = Tempfile.new(["shrine", ".#{extension}"], binmode: true)
-          stream(tempfile, *args)
-          tempfile.open
-        end
+        tempfile = Tempfile.new(["shrine", ".#{extension}"], binmode: true)
+        stream(tempfile, *args)
+        tempfile.open
 
         block_given? ? yield(tempfile) : tempfile
       ensure

--- a/test/linter_test.rb
+++ b/test/linter_test.rb
@@ -23,31 +23,14 @@ describe Shrine::Storage::Linter do
     end
   end
 
-  describe "download" do
-    it "tests that returned object is a Tempfile" do
-      @storage.instance_eval { def download(id); File.open(__FILE__); end }
-      assert_raises(Shrine::LintError) { @linter.call }
-    end
-
-    it "tests that returned IO is not empty" do
-      @storage.instance_eval { def download(id); Tempfile.new(""); end }
-      assert_raises(Shrine::LintError) { @linter.call }
-    end
-
-    it "doesn't require #download to be defined" do
-      @storage.instance_eval { undef download }
-      @linter.call
-    end
-  end
-
   describe "open" do
     it "tests that returned object is an IO" do
-      @storage.instance_eval { def download(id); StringIO.new("foo").tap { |io| io.instance_eval{undef rewind} }; end }
+      @storage.instance_eval { def open(id); StringIO.new("foo").tap { |io| io.instance_eval{undef rewind} }; end }
       assert_raises(Shrine::LintError) { @linter.call }
     end
 
     it "tests that returned IO is not empty" do
-      @storage.instance_eval { def download(id); StringIO.new; end }
+      @storage.instance_eval { def open(id); StringIO.new; end }
       assert_raises(Shrine::LintError) { @linter.call }
     end
   end

--- a/test/support/test_storage.rb
+++ b/test/support/test_storage.rb
@@ -1,15 +1,8 @@
 require "shrine/storage/memory"
-require "tempfile"
 
 class Shrine
   module Storage
     class Test < Memory
-      def download(id)
-        tempfile = Tempfile.new(["shrine", File.extname(id)], binmode: true)
-        IO.copy_stream(open(id), tempfile)
-        tempfile.tap(&:open)
-      end
-
       def move(io, id, **options)
         store[id] = io.storage.delete(io.id)
       end


### PR DESCRIPTION
When `refresh_metadata` plugin is used, `UploadedFile#download` using Storage#download causes bad performance when `UploadedFile#download` is called multiple times during metadata extraction, because in that case the same file will be downloaded from the storage multiple times.

```rb
add_metadata :foo do |io, context|
  io.download { ... } # downloaded from the storage (1st time)
end

add_metadata :bar do |io, context|
  io.download { ... } # downloaded from the storage (2nd time)
end
```

Moreover, the download that `UploadedFile#refresh_metadata!` started at the beginning of metadata extraction won't be reused. It will be reused for determine_mime_type and store_dimensions plugins, but for any custom metadata that uses `UploadedFile#download` (either directly or implicitly via `Shrine.with_file`) a whole new download will be started.

`Storage#download` existed for two reasons:

1. If `Storage#open` uses `Down::ChunkedIO`, calling `UploadedFile#download` the first time on an `UploadedFile` object would copy the remote content to two Tempfiles: the Tempfile that's returned and `Down::ChunkedIO`'s internal Tempfile. `Storage#download` allows storage implementers to avoid the additional copy.

2. Some SDKs such as `aws-sdk-s3` implement automatic retries only if the download destination is a Tempfile (like in `S3#download`), but not if it's a block (like in `S3#open`).

The 1st issue can be addressed by explicitly passing `rewindable: false` for storages that use `Down::ChunkedIO` and support `:rewindable`. Though it's not really a big deal anyway.

The 2nd issue should be fixed in the SDK. `google-api-client` already supports resumable downloads for any download destination, and fix for `aws-sdk-s3` is in the works (https://github.com/aws/aws-sdk-ruby/pull/1617)

I no longer believe `Storage#download` provides enough benefits to keep around. The performance issues with `refresh_metadata` plugin and custom metadata are a great reason to throw it away. An added benefit is that storages now have one less method to implement.

Partially addresses #329