### PR TITLE
Add `file: true` feature to add_metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD
 
+* Add `file: true` option to `add_metadata` plugin for when a block requires a file object (@janko-m)
+
 * Keep `context` argument in `#extract_metadata` optional after loading `add_metadata` plugin (@janko-m)
 
 * Include metadata key with `nil` value when `nil` is returned in `add_metadata` block (@janko-m)


### PR DESCRIPTION
Sometimes to extract metadata the user needs a file object which has a `#path`. Previously the recommended approach was to call `Shrine.with_file` directly:

```rb
add_metadata :custom do |io, context|
  Shrine.with_file(io) do |file|
    # ...
  end
end
```

Other than being a bit verbose, this introduces a performance issue when multiple metadata blocks call `Shrine.with_file` and `refresh_metadata` plugin is used. Because `UploadedFile#download` doesn't implement any kind of memoization, the same file would unnecessarily be copied to disk multiple times.

To solve this, we add the ability to pass `file: true` to `#add_metadata`, in which case Shrine will internally call `Shrine.with_file` around the whole metadata extraction, so the copying to disk will happen only once during whole metadata extraction.

```rb
add_metadata :custom, file: true do |file, context|
  file # this is now a file object
end
```

This is an alternative fix for the problem described in https://github.com/shrinerb/shrine/pull/329.