### PR TITLE
Add derivation_endpoint plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD
 
+* Add `derivation_endpoint` plugin for processing uploaded files on-the-fly (@janko-m)
+
 * Allow Marcel to fall back to the file extension in `determine_mime_type` plugin (@skarlcf)
 
 * Don't return cached app instance in `Shrine.download_endpoint` in `download_endpoint` plugin (@janko-m)

--- a/lib/shrine/plugins/derivation_endpoint.rb
+++ b/lib/shrine/plugins/derivation_endpoint.rb
@@ -294,22 +294,22 @@ class Shrine
     # ## Content Disposition
     #
     # By default in the derivation response, the [`Content-Disposition`] header
-    # sets the disposition to `inline`, while the download filename is
-    # generated from derivation name, arguments and source file id. You can
-    # override this header with the `:disposition` and `:filename` options:
+    # sets the disposition to `inline`, while the download filename is generated
+    # from derivation name, arguments and source file id. You can override that
+    # with the `:disposition` and `:filename` options:
     #
     #     plugin :derivation_endpoint,
-    #       disposition: -> (context) {
-    #         context[:name] == :thumbnail ? "inline" : "attachment"
-    #       },
-    #       filename: -> (context) {
-    #         [context[:name], *context[:args]].join("-")
-    #       }
+    #       disposition: -> (context) { context[:name] == :thumbnail ? "inline" : "attachment" },
+    #       filename:    -> (context) { [context[:name], *context[:args]].join("-") }
+    #
+    # When the user opens the link in the browser, an `inline` disposition will
+    # tell the browser to render the file if possible, while `attachment`
+    # disposition will force download.
     #
     # The `:filename` and `:disposition` options can also be set per URL:
     #
-    #     uploaded_file.derivation_url(:thumbnail, disposition: "inline", filename: "custom-filename")
-    #     #=> "/thumbnail/eyJpZCI6ImZvbyIsInN?disposition=inline&filename=custom-filename&signature=..."
+    #     uploaded_file.derivation_url(:pdf, disposition: "attachment", filename: "custom-filename")
+    #     #=> "/thumbnail/eyJpZCI6ImZvbyIsInN?disposition=attachment&filename=custom-filename&signature=..."
     #
     # ## Uploading
     #

--- a/lib/shrine/plugins/derivation_endpoint.rb
+++ b/lib/shrine/plugins/derivation_endpoint.rb
@@ -1,0 +1,1063 @@
+# frozen_string_literal: true
+
+require "rack"
+require "content_disposition"
+
+require "openssl"
+
+class Shrine
+  module Plugins
+    # The `derivation_endpoint` plugin provides a Rack app for dynamically
+    # processing uploaded files on request. This allows you to create URLs to
+    # files that haven't been processed yet, and have the endpoint process them
+    # on-the-fly.
+    #
+    # ## Usage
+    #
+    # When loading the plugin, you need to provide a secret key, which will be
+    # used to sign URLs. We also need to provide a path prefix where the
+    # endpoint will be mounted, which will be added to generated URLs.
+    #
+    #     class ImageUploader < Shrine
+    #       plugin :derivation_endpoint,
+    #         secret_key: "<your-secret-key>",
+    #         prefix:     "deriatives/image"
+    #     end
+    #
+    # ### Mounting endpoint
+    #
+    # We can then mount an endpoint for a specific uploader into our app's
+    # router on the specified path prefix:
+    #
+    #     # config.ru (Rack)
+    #     map "/derivations/image" do
+    #       run ImageUploader.derivation_endpoint
+    #     end
+    #
+    #     # OR
+    #
+    #     # config/routes.rb (Rails)
+    #     Rails.application.routes.draw do
+    #       mount ImageUploader.derivation_endpoint => "/derivations/image"
+    #     end
+    #
+    # ### Defining derivations
+    #
+    # Now that the endpoint is set up, we can define derivations on our
+    # uploader. Derivations are defined with a name and a block:
+    #
+    #     class ImageUploader < Shrine
+    #       derivation :thumbnail do |file, *args|
+    #         # ...
+    #       end
+    #     end
+    #
+    # The name uniquely identifies the derivation, and will be used when
+    # generating URLs. The block is called whenever the derivation endpoint
+    # receives a request for that derivation. The first argument is the
+    # original uploaded file downloaded to disk, and the rest are the arguments
+    # for the derivation provided when generating the URL. The block *must*
+    # return a file object, and that will be returned in the response.
+    #
+    # Let's use the [ImageProcessing] gem to generate some thumbnails:
+    #
+    #     require "image_processing/mini_magick"
+    #
+    #     class ImageUploader < Shrine
+    #       derivation :thumbnail do |file, width, height|
+    #         ImageProcessing::MiniMagick
+    #           .source(file)
+    #           .resize_to_limit!(width.to_i, height.to_i)
+    #       end
+    #     end
+    #
+    # ### Generating URLs
+    #
+    # Now we can call `#derivation_url` on an uploaded file to generate a URL
+    # for a specific thumbnail:
+    #
+    #     photo.image.derivation_url(:thumbnail, "500", "400")
+    #     #=> "/derivations/image/thumbnail/500/400/eyJpZCI6ImZvbyIsInN0b3JhZ2UiOiJzdG9yZSJ9?signature=..."
+    #
+    # The first argument is the derivation name, while the rest are arguments
+    # that will be passed to the derivation block. They are included in the URL
+    # path, along will the serialized uploaded file that will be used as the
+    # source file. The URL is signed with the secret key to prevent tampering.
+    #
+    # The example above assumes that `photo` is an instance of a `Photo` model
+    # which defines an `image` attachment. Calling `photo.image` returns an
+    # instance of `Shrine::UploadedFile` given that a file has been attached.
+    #
+    # ### Performance considerations
+    #
+    # Unless you've enabled `:upload` and `:upload_redirect` options, the
+    # derivation endpoint will generate and serve derivatives on each request.
+    # This can take a lot of resources, so you want it to happen rarely.
+    #
+    # Therefore, it's highly recommended to put a **CDN or other HTTP cache**
+    # in front of your application. Once you have that, you can have derivation
+    # URLs point to the CDN by setting the `:host` option:
+    #
+    #     plugin :derivation_endpoint, host: "https://your-dist-url.cloudfront.net"
+    #
+    # You can also set `:upload`, which will make the derivation endpoint cache
+    # processed derivatives on the storage, so that processing happens only on
+    # initial request. If you also set `:upload_redirect`, the endpoint will
+    # redirect to the cached derivative on the storage instead of serving it.
+    #
+    #     plugin :derivation_endpoint, upload: true
+    #
+    # These two strategies are not mutually exclusive, you can use both.
+    #
+    # ## Derivation response
+    #
+    # There are three ways to generate derivation responses. First is the one
+    # we've already seen, which is to plug the Rack app into our router.
+    #
+    #     # config/routes.rb
+    #     Rails.application.routes.draw do
+    #       mount ImageUploader.derivation_endpoint => "/derivations/image"
+    #     end
+    #
+    # Second way keeps the URL format, but allows you to route the request to
+    # a custom controller. Inside the controller you can call
+    # `Shrine.derivation_response` with the Rack env hash to handle the
+    # request. The target derivation name and arguments are inferred from
+    # the request information. The return value is an array of the status,
+    # headers, and body that should be set for the top-level response.
+    #
+    #     # config/routes.rb
+    #     Rails.application.routes.draw do
+    #       get "/derivations/image/*rest" => "derivations#image"
+    #     end
+    #
+    #     # app/controllers/derivations_controller.rb
+    #     class DerivationsController < ApplicationController
+    #       def image
+    #         set_rack_response ImageUploader.derivation_response(request.env)
+    #       end
+    #
+    #       private
+    #
+    #       def set_rack_response((status, headers, body))
+    #         self.status = status
+    #         self.headers.merge!(headers)
+    #         self.response_body = body
+    #       end
+    #     end
+    #
+    # This approach gives greater flexibility as it allows executing additional
+    # code on the controller level before and after generating a derivation
+    # response. This might make operations like authentication easier.
+    #
+    # The third way allows you to use custom URLs for derivations. In the
+    # controller you can call `#derivation_response` directly on the
+    # `UploadedFile`, passing the derivation name, arguments, and the Rack env
+    # hash.
+    #
+    #     # config/routes.rb
+    #     Rails.application.routes.draw do
+    #       resources :photos do
+    #         member do
+    #           get "thumbnail" # for example
+    #         end
+    #       end
+    #     end
+    #
+    #     # app/controllers/photos_controller.rb
+    #     class PhotosController < ApplicationController
+    #       def thubmnail
+    #         photo = Photos.find(params[:id])
+    #         image = photo.image
+    #
+    #         set_rack_response image.derivation_response(:thumbnail, 300, 300, env: request.env)
+    #       end
+    #
+    #       private
+    #
+    #       def set_rack_response((status, headers, body))
+    #         self.status = status
+    #         self.headers.merge!(headers)
+    #         self.response_body = body
+    #       end
+    #     end
+    #
+    # This approach for example allows authorizing access to derivatives, as we
+    # can access the database record to which the uploaded file belongs to
+    # prior to generating a derivation response.
+    #
+    # The `Shrine.derivation_endpoint`, `Shrine.derivation_response`, and
+    # `UploadedFile#derivation_response` all accept additional options, which
+    # override any options set on the plugin level.
+    #
+    #     ImageUploader.derivation_endpoint(disposition: "attachment")
+    #     # or
+    #     ImageUploader.derivation_response(env, disposition: "attachment")
+    #     # or
+    #     uploaded_file.derivation_response(:thumbnail, env: env, disposition: "attachment")
+    #
+    # ## Dynamic options
+    #
+    # When passing options to the plugin, to `Shrine.derivation_endpoint`,
+    # `Shrine.derivation_response`, or to
+    # `Shrine::UploadedFile#derivation_response`, for most options the value
+    # can be a block that returns a dynamic result. The block will be called
+    # with a context hash containing `:name`, `:args`, and `:uploaded_file`.
+    #
+    #     plugin :derivation_endpoint, disposition: -> (context) do
+    #       context[:name]          #=> :thumbnail
+    #       context[:args]          #=> ["500", "400"]
+    #       context[:uploaded_file] #=> #<Shrine::UploadedFile>
+    #
+    #       # ...
+    #     end
+    #
+    # For example, we can use it to specify that thumbnails should be rendered
+    # inline by the browser, while other derivatives should be downloaded.
+    #
+    #     plugin :derivation_endpoint, disposition: -> (context) do
+    #       if context[:name] == :thumbnail
+    #         "inline"
+    #       else
+    #         "attachment"
+    #       end
+    #     end
+    #
+    # ## Host
+    #
+    # By default generated URLs are relative. To generate absolute URLs, you
+    # can pass the `:host` option:
+    #
+    #     plugin :derivation_endpoint, host: "https://example.com"
+    #
+    # Now the generated URLs will include the specified URL host:
+    #
+    #     uploaded_file.derivation_url(:thumbnail)
+    #     #=> "https://example.com/thumbnail/eyJpZCI6ImZvbyIsInN?signature=..."
+    #
+    # You can also pass `:host` per URL:
+    #
+    #     uploaded_file.derivation_url(:thumbnail, host: "https://example.com")
+    #     #=> "https://example.com/thumbnail/eyJpZCI6ImZvbyIsInN?signature=..."
+    #
+    # ## Prefix
+    #
+    # If you're mounting the derivation endpoint under a path prefix, the
+    # `:prefix` option needs to match in order for correct URLs to be generated:
+    #
+    #     plugin :derivation_endpoint, prefix: "derivations/image"
+    #
+    # Now generated URLs will include the specified path prefix:
+    #
+    #     uploaded_file.derivation_url(:thumbnail)
+    #     #=> "/derivations/image/thumbnail/eyJpZCI6ImZvbyIsInN?signature=..."
+    #
+    # You can also pass `:prefix` per URL:
+    #
+    #     uploaded_file.derivation_url(:thumbnail, prefix: "derivations/image")
+    #     #=> "/derivations/image/thumbnail/eyJpZCI6ImZvbyIsInN?signature=..."
+    #
+    # ## Expiration
+    #
+    # By default generated URLs are valid indefinitely. If you want URLs to
+    # expire after a certain amount of time, you can set the `:expires_in`
+    # option:
+    #
+    #     plugin :derivation_endpoint, expires_in: 90
+    #
+    # Now any URL will stop being valid 90 seconds after it was generated:
+    #
+    #     uploaded_file.derivation_url(:thumbnail)
+    #     #=> "/thumbnail/eyJpZCI6ImZvbyIsInN?expires_at=1547843568&signature=..."
+    #
+    # You can also pass `:expires_in` per URL:
+    #
+    #     uploaded_file.derivation_url(:thumbnail, expires_in: 90)
+    #     #=> "/thumbnail/eyJpZCI6ImZvbyIsInN?expires_at=1547843568&signature=..."
+    #
+    # ## Content Type
+    #
+    # By default in the derivation response, the [`Content-Type`] header is
+    # inferred from the file extension of the derivative (using `Rack::Mime`).
+    # You can override that with the `:type` option:
+    #
+    #     plugin :derivation_endpoint, type: -> (context) do
+    #       "image/webp" if context[:name] == :webp
+    #     end
+    #
+    # If the block returns `nil`, then the default type will be set. You can
+    # also set `:type` per URL:
+    #
+    #     uploaded_file.derivation_url(:webp, type: "image/webp")
+    #     #=> "/webp/eyJpZCI6ImZvbyIsInN?type=image%2Fwebp&signature=..."
+    #
+    # ## Content Disposition
+    #
+    # By default in the derivation response, the [`Content-Disposition`] header
+    # sets the disposition to `inline`, while the download filename is
+    # generated from derivation name, arguments and source file id. You can
+    # override this header with the `:disposition` and `:filename` options:
+    #
+    #     plugin :derivation_endpoint,
+    #       disposition: -> (context) {
+    #         context[:name] == :thumbnail ? "inline" : "attachment"
+    #       },
+    #       filename: -> (context) {
+    #         [context[:name], *context[:args]].join("-")
+    #       }
+    #
+    # The `:filename` and `:disposition` options can also be set per URL:
+    #
+    #     uploaded_file.derivation_url(:thumbnail, disposition: "inline", filename: "custom-filename")
+    #     #=> "/thumbnail/eyJpZCI6ImZvbyIsInN?disposition=inline&filename=custom-filename&signature=..."
+    #
+    # ## Uploading
+    #
+    # By default the derivation from a source file will be called each time
+    # it's requested. However, you can cache the derivatives to a storage by
+    # setting `:upload` to `true`. On first request the generated derivative
+    # will be uploaded to storage, and then on subsequent requests the already
+    # uploaded derivative will be served from the storage.
+    #
+    #     plugin :derivation_endpoint, upload: true
+    #
+    # The target storage used is the same as for the source uploaded file, but
+    # it can be changed via `:upload_storage`:
+    #
+    #     plugin :derivation_endpoint, upload: true,
+    #                                  upload_storage: :thumbnail_storage
+    #
+    # The derivative will be uploaded to `<source id>/<name>-<args>` by default,
+    # and can be changed via `:upload_location`:
+    #
+    #     plugin :derivation_endpoint, upload: true, upload_location: -> (context) do
+    #       # e.g. "derivatives/9a7d1bfdad24a76f9cfaff137fe1b5c7/thumbnail-1000-800"
+    #       [
+    #         "derivatives",
+    #         File.basename(context[:uploaded_file].id, ".*"),
+    #         [context[:name], *context[:args]].join("-")
+    #       ].join("/")
+    #     end
+    #
+    # Additional storage-specific upload options can be passed via
+    # `:upload_options`:
+    #
+    #     plugin :derivation_endpoint, upload: true,
+    #                                  upload_options: { acl: "public-read" }
+    #
+    # ### Redirecting
+    #
+    # The derivative content will be served through the endpoint by default.
+    # However, you can configure the endpoint to redirect to the uploaded
+    # derivative on the storage:
+    #
+    #     plugin :derivation_endpoint, upload: true,
+    #                                  upload_redirect: true
+    #
+    # In that case additional storage-specific URL options can also be passed in:
+    #
+    #     plugin :derivation_endpoint, upload: true,
+    #                                  upload_redirect: true,
+    #                                  upload_redirect_url_options: { public: true }
+    #
+    # ## Cache busting
+    #
+    # The derivation endpoint returns `Cache-Control` header in the derivation
+    # response telling HTTP caches like CDNs to cache the response for a year.
+    # So if you change how a derivation is being performed, users might still
+    # see the previous version of the derivative if it was already generated
+    # and cached.
+    #
+    # If you want the already cached derivatives to be re-generated, you can
+    # add a "version" parameter to the URL, which will make HTTP caches treat
+    # is as a new URL. You can do this by via the `:version` option. You
+    # probably want to bump the version only of the derivations that you've
+    # changed.
+    #
+    #     plugin :derivation_endpoint, version: -> (context) do
+    #       context[:name] == :thumbnail ? 1 : nil
+    #     end
+    #
+    # Now all `:thumbnail` derivation URLs will include `version` in the query
+    # string:
+    #
+    #     uploaded_file.derivation_url(:thumbnail)
+    #     #=> "/thumbnail/eyJpZCI6ImZvbyIsInN?version=1&signature=..."
+    #
+    # You can also bump the `:version` per URL:
+    #
+    #     uploaded_file.derivation_url(:thumbnail, version: 1)
+    #     #=> "/thumbnail/eyJpZCI6ImZvbyIsInN?version=1&signature=..."
+    #
+    # ## Accessing uploaded file
+    #
+    # If you want to access the source `UploadedFile` object when deriving, you
+    # can set `:include_uploaded_file` to `true`.
+    #
+    #     plugin :derivation_endpoint, include_uploaded_file: true
+    #
+    # Now the source `UploadedFile` will be passed as the second argument of
+    # the derivation block:
+    #
+    #     derivation :thumbnail do |file, uploaded_file, width, height|
+    #       uploaded_file             #=> #<Shrine::UploadedFile>
+    #       uploaded_file.id          #=> "9a7d1bfdad24a76f9cfaff137fe1b5c7.jpg"
+    #       uploaded_file.storage_key #=> "store"
+    #       uploaded_file.metadata    #=> {}
+    #
+    #       # ...
+    #     end
+    #
+    # By default original metadata that was extracted during attachment isn't
+    # available, to keep the derivation URL as short as possible. However, if
+    # you want to have original metadata available when deriving, you can set
+    # the `:metadata` option to the list of needed metadata values:
+    #
+    #     plugin :derivation_endpoint, metadata: ["filename", "mime_type"]
+    #
+    # Now `filename` and `mime_type` metadata values will be available in the
+    # derivation block:
+    #
+    #     derivation :thumbnail do |file, uploaded_file, width, height|
+    #       uploaded_file.metadata #=>
+    #       # {
+    #       #  "filename" => "nature.jpg",
+    #       #  "mime_type" => "image/jpeg"
+    #       # }
+    #
+    #       uploaded_file.original_filename #=> "nature.jpg"
+    #       uploaded_file.mime_type         #=> "image/jpeg"
+    #
+    #       # ...
+    #     end
+    #
+    # ## Downloading
+    #
+    # When a derivation is requested, the original uploaded file will be
+    # downloaded to disk before the derivation block is called. If you want
+    # to pass in additional storage-specific download options, you can do so
+    # via `:download_options`:
+    #
+    #     plugin :derivation_endpoint, download_options: {
+    #       sse_customer_algorithm: "AES256",
+    #       sse_customer_key:       "secret_key",
+    #       sse_customer_key_md5:   "secret_key_md5",
+    #     }
+    #
+    # When using `Shrine.derivation_endpoint` or `Shrine.derivation_response`,
+    # if the original uploaded file has been deleted, the error the storage
+    # raises when attempting to download it will be propagated by default. You
+    # can choose to have the endpoint convert these errors to 404 responses by
+    # adding them to `:download_errors`:
+    #
+    #     plugin :derivation_endpoint, download_errors: [
+    #       Errno::ENOENT,              # raised by Shrine::Storage::FileSystem
+    #       Aws::S3::Errors::NoSuchKey, # raised by Shrine::Storage::S3
+    #     ]
+    #
+    # If you don't want the uploaded file to be downloaded to disk for you, set
+    # `:download` to `false`.
+    #
+    #     plugin :derivation_endpoint, download: false
+    #
+    # In this case the `UploadedFile` object is yielded to the derivation block
+    # instead of the raw file:
+    #
+    #     derivation :thumbnail do |uploaded_file, width, height|
+    #       uploaded_file #=> #<Shrine::UploadedFile>
+    #
+    #       # ...
+    #     end
+    #
+    # ## Plugin Options
+    #
+    # :disposition
+    # :  Whether the browser should attempt to render the derivative (`inline`)
+    #    or prompt the user to download the file to disk (`attachment`)
+    #    (default: `inline`)
+    #
+    # :download
+    # :  Whether the source uploaded file should be downloaded to disk when the
+    #    derivation block is called (default: `true`).
+    #
+    # :download_errors
+    # :  List of error classes that will be converted to a `404 Not Found`
+    #    response by the derivation endpoint (default: `[]`)
+    #
+    # :download_options
+    # :  Additional options to pass when downloading the source uploaded file
+    #    (default: `{}`)
+    #
+    # :expires_in
+    # :  Number of seconds after which the URL will not be available anymore
+    #    (default: `nil`)
+    #
+    # :filename
+    # :  Filename the browser will assume when the derivative is downloaded to
+    #    disk (default: `<name>-<args>-<source id basename>`)
+    #
+    # :host
+    # :  URL host to use when generated URLs (default: `nil`)
+    #
+    # :include_uploaded_file
+    # :  Whether to include the source uploaded file in the derivation block
+    #    arguments (default: `false`)
+    #
+    # :metadata
+    # :  List of metadata keys the source uploaded file should include in the
+    #    derivation block (default: `[]`)
+    #
+    # :prefix
+    # :  Path prefix added to the URLs (default: `nil`)
+    #
+    # :secret_key
+    # :  Key that's used to sign derivation URLs in order to prevent tampering
+    #    (required)
+    #
+    # :type
+    # :  Media type returned in the `Content-Type` response header in the
+    #    derivation response (default: determined from derivative's extension)
+    #
+    # :upload
+    # :  Whether the generated derivatives will be cached on the storage
+    #    (default: `false`)
+    #
+    # :upload_location
+    # :  Location to which the derivatives will be uploaded on the storage
+    #    (default: `<source id>/<name>-<args>`)
+    #
+    # :upload_options
+    # :  Additional options to be passed when uploading derivatives
+    #    (default: `{}`)
+    #
+    # :upload_redirect
+    # :  Whether the derivation response should redirect to the uploaded
+    #    derivative (default: `false`)
+    #
+    # :upload_redirect_url_options
+    # :  Additional options to be passed when generating the URL for the
+    #    uploaded derivative (default: `{}`)
+    #
+    # :upload_storage
+    # :  Storage to which the derivations will be uploaded (default: same
+    #    storage as the source file)
+    #
+    # :version
+    # :  Version number to append to the URL for cache busting (default: `nil`)
+    #
+    # [ImageProcessing]: https://github.com/janko-m/image_processing
+    # [`Content-Type`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type
+    # [`Content-Disposition`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition
+    module DerivationEndpoint
+      class SourceNotFound < Error; end
+
+      def self.load_dependencies(uploader, opts = {})
+        uploader.plugin :rack_response if opts[:upload] && opts[:upload_redirect] != true
+        uploader.plugin :_urlsafe_serialization
+      end
+
+      def self.configure(uploader, opts = {})
+        uploader.opts[:derivation_endpoint_options] ||= {}
+        uploader.opts[:derivation_endpoint_options].merge!(opts)
+
+        uploader.opts[:derivation_endpoint_definitions] ||= {}
+
+        unless uploader.opts[:derivation_endpoint_options][:secret_key]
+          fail Error, ":secret_key option is required for derivation_endpoint plugin"
+        end
+      end
+
+      module ClassMethods
+        def derivation_endpoint(**options)
+          App.new(shrine_class: self, options: options)
+        end
+
+        def derivation_response(env, **options)
+          script_name = env["SCRIPT_NAME"]
+          path_info   = env["PATH_INFO"]
+
+          prefix = derivation_options[:prefix]
+          match  = path_info.match(/^\/#{prefix}/)
+
+          fail Error, "expected request path \"#{path_info}\" to start with \"/#{prefix}\"" unless match
+
+          begin
+            env["SCRIPT_NAME"] += match.to_s
+            env["PATH_INFO"]    = match.post_match
+
+            derivation_endpoint(**options).call(env)
+          ensure
+            env["SCRIPT_NAME"] = script_name
+            env["PATH_INFO"]   = path_info
+          end
+        end
+
+        def derivation(name, &block)
+          derivations[name] = block
+        end
+
+        def find_derivation(name)
+          derivations[name] or fail Error, "derivation #{name.inspect} is not defined"
+        end
+
+        def derivations
+          opts[:derivation_endpoint_definitions]
+        end
+
+        def derivation_options
+          opts[:derivation_endpoint_options]
+        end
+      end
+
+      module FileMethods
+        def derivation_url(name, *args, **options)
+          derivation(name, *args).url(**options)
+        end
+
+        def derivation_response(name, *args, env:, **options)
+          derivation(name, *args, **options).response(env)
+        end
+
+        private
+
+        def derivation(name, *args, **options)
+          Derivation.new(
+            name:    name,
+            args:    args,
+            source:  self,
+            options: options,
+          )
+        end
+      end
+
+      class Derivation
+        def self.option(name, default: nil)
+          define_method(name) do
+            value = resolve_option(name)
+            value = instance_exec(&default) if value.nil? && default
+            value
+          end
+          private(name)
+        end
+
+        attr_reader :name, :args, :source, :options
+
+        def initialize(name:, args:, source:, options:)
+          @name    = name
+          @args    = args
+          @source  = source
+          @options = options
+        end
+
+        option :disposition,                 default: -> { "inline" }
+        option :download,                    default: -> { true }
+        option :download_errors,             default: -> { [] }
+        option :download_options,            default: -> { {} }
+        option :expires_in
+        option :filename,                    default: -> { default_filename }
+        option :host
+        option :include_uploaded_file,       default: -> { false }
+        option :metadata,                    default: -> { [] }
+        option :prefix
+        option :secret_key
+        option :type
+        option :upload,                      default: -> { false }
+        option :upload_location,             default: -> { default_upload_location }
+        option :upload_options,              default: -> { {} }
+        option :upload_redirect,             default: -> { false }
+        option :upload_redirect_url_options, default: -> { {} }
+        option :upload_storage,              default: -> { source.storage_key.to_sym }
+        option :version
+
+        def url(**options)
+          derivation_url = Derivation::Url.new(
+            name:       name,
+            args:       args,
+            file:       source,
+            secret_key: secret_key,
+          )
+
+          derivation_url.call(
+            host:       host,
+            prefix:     prefix,
+            expires_in: expires_in,
+            version:    version,
+            metadata:   metadata,
+            **options,
+          )
+        end
+
+        def response(env)
+          derivation_response = Derivation::Response.new(
+            name:                        name,
+            args:                        args,
+            source:                      source,
+            env:                         env,
+            type:                        type,
+            disposition:                 disposition,
+            filename:                    filename,
+            download:                    download,
+            download_errors:             download_errors,
+            download_options:            download_options,
+            include_uploaded_file:       include_uploaded_file,
+            upload:                      upload,
+            upload_storage:              upload_storage,
+            upload_location:             upload_location,
+            upload_options:              upload_options,
+            upload_redirect:             upload_redirect,
+            upload_redirect_url_options: upload_redirect_url_options,
+            version:                     version,
+          )
+
+          derivation_response.call
+        end
+
+        private
+
+        def resolve_option(name)
+          value = options[name] || shrine_class.derivation_options[name]
+          value = value.call(name: name, args: args, uploaded_file: source) if value.respond_to?(:call)
+          value
+        end
+
+        def default_filename
+          [name, *args, File.basename(source.id, ".*")].join("-")
+        end
+
+        def default_upload_location
+          directory = source.id.sub(/\.[^\/]+/, "")
+          filename  = [name, *args].join("-")
+
+          [directory, filename].join("/")
+        end
+
+        def shrine_class
+          source.shrine_class
+        end
+      end
+
+      class Derivation::Url
+        attr_reader :name, :args, :file, :secret_key
+
+        def initialize(name:, args:, file:, secret_key:)
+          @name       = name
+          @args       = args
+          @file       = file
+          @secret_key = secret_key
+        end
+
+        def call(host: nil, prefix: nil, **options)
+          [host, *prefix, identifier(**options)].join("/")
+        end
+
+        private
+
+        def identifier(expires_in: nil,
+                       version: nil,
+                       type: nil,
+                       filename: nil,
+                       disposition: nil,
+                       metadata: [])
+
+          params = {}
+          params[:expires_at]  = (Time.now.utc + expires_in).to_i if expires_in
+          params[:version]     = version if version
+          params[:type]        = type if type
+          params[:filename]    = filename if filename
+          params[:disposition] = disposition if disposition
+
+          file_component = file.urlsafe_dump(metadata: metadata)
+
+          signed_url(name, *args, file_component, params)
+        end
+
+        def signed_url(*components)
+          signer = Signer.new(secret_key)
+          signer.signed_url(*components)
+        end
+      end
+
+      class App
+        attr_reader :shrine_class, :options
+
+        def initialize(shrine_class:, options: {})
+          @shrine_class = shrine_class
+          @options      = options
+        end
+
+        def call(env)
+          request = Rack::Request.new(env)
+
+          status, headers, body = catch(:halt) do
+            error!(405, "Method not allowed") unless request.get? || request.head?
+
+            handle_request(request)
+          end
+
+          headers["Content-Length"] ||= body.map(&:bytesize).inject(0, :+).to_s
+
+          [status, headers, body]
+        end
+
+        def handle_request(request)
+          verify_signature!(request)
+          check_expiry!(request)
+
+          name, *args, serialized_file = request.path_info.split("/")[1..-1]
+
+          name          = name.to_sym
+          uploaded_file = shrine_class::UploadedFile.urlsafe_load(serialized_file)
+
+          unless shrine_class.derivations.key?(name)
+            error!(404, "Unknown derivation \"#{name}\"")
+          end
+
+          # request params override statically configured options
+          options = self.options.dup
+          options[:type]        = request.params["type"]        if request.params["type"]
+          options[:disposition] = request.params["disposition"] if request.params["disposition"]
+          options[:filename]    = request.params["filename"]    if request.params["filename"]
+
+          begin
+            status, headers, body = uploaded_file.derivation_response(
+              name, *args, env: request.env, **options,
+            )
+          rescue SourceNotFound
+            error!(404, "Source file not found")
+          end
+
+          if status == 200 || status == 206
+            headers["Cache-Control"] = "public, max-age=#{365*24*60*60}" # cache for a year
+          end
+
+          [status, headers, body]
+        end
+
+        private
+
+        def verify_signature!(request)
+          signer = Signer.new(secret_key)
+          signer.verify_url("#{request.path_info[1..-1]}?#{request.query_string}")
+        rescue Signer::InvalidSignature => error
+          error!(403, error.message.capitalize)
+        end
+
+        def check_expiry!(request)
+          return if request.params["expires_at"].nil?
+
+          expires_at = Integer(request.params["expires_at"])
+
+          error!(403, "Request has expired") if Time.now > Time.at(expires_at)
+        end
+
+        # Halts the request with the error message.
+        def error!(status, message)
+          throw :halt, [status, { "Content-Type" => "text/plain" }, [message]]
+        end
+
+        def secret_key
+          shrine_class.derivation_options[:secret_key]
+        end
+      end
+
+      class Derivation::Response
+        DEFAULT_MIME_TYPE = "application/octet-stream"
+
+        attr_reader :name, :args, :source, :env, :type, :disposition,
+          :filename, :download, :download_errors, :download_options, :upload,
+          :upload_storage, :upload_options, :upload_redirect,
+          :upload_redirect_url_options, :include_uploaded_file, :version
+
+        def initialize(**options)
+          options.each do |name, value|
+            instance_variable_set(:"@#{name}", value)
+          end
+        end
+
+        def call
+          if upload
+            upload_response
+          else
+            local_response
+          end
+        end
+
+        private
+
+        def local_response
+          derivative = call_derivation
+
+          file_response(derivative)
+        end
+
+        def file_response(file)
+          file.close
+          response = rack_file_response(file.path)
+
+          status = response[0]
+
+          filename  = self.filename
+          filename += File.extname(file.path) if File.extname(filename).empty?
+
+          headers = {}
+          headers["Content-Type"]        = type || response[1]["Content-Type"]
+          headers["Content-Disposition"] = content_disposition(filename)
+          headers["Content-Length"]      = response[1]["Content-Length"]
+          headers["Content-Range"]       = response[1]["Content-Range"] if response[1]["Content-Range"]
+          headers["Accept-Ranges"]       = "bytes"
+
+          body = Rack::BodyProxy.new(response[2]) { file.delete }
+
+          [status, headers, body]
+        end
+
+        def upload_response
+          storage = shrine_class.find_storage(upload_storage)
+
+          if storage.exists?(upload_location)
+            uploaded_file = shrine_class::UploadedFile.new(
+              "storage" => upload_storage,
+              "id"      => upload_location,
+            )
+          else
+            derivative = call_derivation
+
+            uploader      = shrine_class.new(upload_storage)
+            uploaded_file = uploader.upload derivative,
+              location:       upload_location,
+              upload_options: upload_options
+          end
+
+          if upload_redirect
+            derivative.unlink if derivative
+
+            redirect_url = uploaded_file.url(upload_redirect_url_options)
+
+            [302, { "Location" => redirect_url }, []]
+          else
+            if derivative
+              file_response(derivative)
+            else
+              uploaded_file.to_rack_response(
+                type:        type,
+                disposition: disposition,
+                filename:    filename,
+                range:       env["HTTP_RANGE"],
+              )
+            end
+          end
+        end
+
+        def call_derivation
+          derivation_block = shrine_class.find_derivation(name)
+          uploader         = source.uploader
+
+          derivative = if download
+            download_source do |file|
+              if include_uploaded_file
+                uploader.instance_exec(file, source, *args, &derivation_block)
+              else
+                uploader.instance_exec(file, *args, &derivation_block)
+              end
+            end
+          else
+            uploader.instance_exec(source, *args, &derivation_block)
+          end
+
+          unless derivative.respond_to?(:path)
+            fail Error, "expected derivation to be a file object, but was #{derivative.inspect}"
+          end
+
+          derivative
+        end
+
+        def download_source
+          download_args = [download_options].reject(&:empty?)
+
+          begin
+            file = source.download(*download_args)
+          rescue *download_errors
+            raise SourceNotFound, "source uploaded file \"#{source.id}\" was not found on storage :#{source.storage_key}"
+          end
+
+          yield file
+        ensure
+          file.close! if file
+        end
+
+        def rack_file_response(path)
+          server = Rack::File.new("", {}, DEFAULT_MIME_TYPE)
+
+          if Rack.release > "2"
+            server.serving(Rack::Request.new(env), path)
+          else
+            server = server.dup
+            server.path = path
+            server.serving(env)
+          end
+        end
+
+        def content_disposition(filename)
+          ContentDisposition.format(disposition: disposition, filename: filename)
+        end
+
+        def upload_location
+          if version
+            @upload_location.sub(/(?=(\.\w+)?$)/, "-#{version}")
+          else
+            @upload_location
+          end
+        end
+
+        def shrine_class
+          source.shrine_class
+        end
+      end
+
+      class Signer
+        InvalidSignature = Class.new(StandardError)
+
+        attr_reader :secret_key
+
+        def initialize(secret_key)
+          @secret_key = secret_key
+        end
+
+        def signed_url(*components, params)
+          path  = Rack::Utils.escape_path(components.join("/"))
+          query = Rack::Utils.build_query(params)
+
+          signature = generate_signature("#{path}?#{query}")
+
+          query = Rack::Utils.build_query(params.merge(signature: signature))
+
+          "#{path}?#{query}"
+        end
+
+        def verify_url(path_with_query)
+          path, query = path_with_query.split("?")
+
+          params    = Rack::Utils.parse_query(query.to_s)
+          signature = params.delete("signature")
+          query     = Rack::Utils.build_query(params)
+
+          verify_signature("#{path}?#{query}", signature)
+        end
+
+        def verify_signature(string, signature)
+          if signature.nil?
+            fail InvalidSignature, "signature is missing"
+          elsif signature != generate_signature(string)
+            fail InvalidSignature, "provided signature doesn't match the expected"
+          end
+        end
+
+        def generate_signature(string)
+          OpenSSL::HMAC.hexdigest(OpenSSL::Digest::SHA256.new, secret_key, string)
+        end
+      end
+    end
+
+    register_plugin(:derivation_endpoint, DerivationEndpoint)
+  end
+end

--- a/lib/shrine/plugins/derivation_endpoint.rb
+++ b/lib/shrine/plugins/derivation_endpoint.rb
@@ -552,7 +552,7 @@ class Shrine
       class SourceNotFound < Error; end
 
       def self.load_dependencies(uploader, opts = {})
-        uploader.plugin :rack_response if opts[:upload] && opts[:upload_redirect] != true
+        uploader.plugin :rack_response
         uploader.plugin :_urlsafe_serialization
       end
 

--- a/lib/shrine/plugins/derivation_endpoint.rb
+++ b/lib/shrine/plugins/derivation_endpoint.rb
@@ -219,6 +219,8 @@ class Shrine
     # access information about the current derivation:
     #
     #     plugin :derivation_endpoint, disposition: -> {
+    #       self   #=> #<Shrine::Derivation>
+    #
     #       name   #=> :thumbnail
     #       args   #=> ["500", "400"]
     #       source #=> #<Shrine::UploadedFile>
@@ -671,7 +673,7 @@ class Shrine
         uploader.opts[:derivation_endpoint_options] ||= {}
         uploader.opts[:derivation_endpoint_options].merge!(opts)
 
-        uploader.opts[:derivation_endpoint_definitions] ||= {}
+        uploader.opts[:derivation_endpoint_derivations] ||= {}
 
         unless uploader.opts[:derivation_endpoint_options][:secret_key]
           fail Error, ":secret_key option is required for derivation_endpoint plugin"
@@ -708,7 +710,7 @@ class Shrine
         end
 
         def derivations
-          opts[:derivation_endpoint_definitions]
+          opts[:derivation_endpoint_derivations]
         end
 
         def derivation_options

--- a/lib/shrine/plugins/derivation_endpoint.rb
+++ b/lib/shrine/plugins/derivation_endpoint.rb
@@ -715,7 +715,7 @@ class Shrine
         private
 
         def resolve_option(name)
-          value = options[name] || shrine_class.derivation_options[name]
+          value = options.fetch(name) { shrine_class.derivation_options[name] }
           value = value.call(name: name, args: args, uploaded_file: source) if value.respond_to?(:call)
           value
         end

--- a/lib/shrine/plugins/derivation_endpoint.rb
+++ b/lib/shrine/plugins/derivation_endpoint.rb
@@ -973,7 +973,7 @@ class Shrine
           end
 
           unless derivative.respond_to?(:path)
-            fail Error, "expected derivation to be a file object, but was #{derivative.inspect}"
+            fail Error, "expected derivative to be a file object, but was #{derivative.inspect}"
           end
 
           derivative

--- a/lib/shrine/plugins/derivation_endpoint.rb
+++ b/lib/shrine/plugins/derivation_endpoint.rb
@@ -532,19 +532,19 @@ class Shrine
     #     uploaded_file    #=> #<Shrine::UploadedFile>
     #     uploaded_file.id #=> "bcfd0d67e4a8ec2dc9a6d7ddcf3825a1/thumbnail-500-500"
     #
-    # ### `#call`
+    # ### `#generate`
     #
     # `Derivation#call` method calls the derivation block and returns the
     # result.
     #
-    #     result = derivation.call
+    #     result = derivation.generate
     #     result #=> #<Tempfile:...>
     #
     # Internally it will download the source uploaded file to disk and pass it
     # to the derivation block (unless `:download` was disabled). You can
     # also pass in an already downloaded source file:
     #
-    #     derivation.call(source_file)
+    #     derivation.generate(source_file)
     #
     # ### `#upload`
     #
@@ -774,8 +774,8 @@ class Shrine
       Derivation::Processed.new(self).call
     end
 
-    def call(file = nil)
-      Derivation::Call.new(self).call(file)
+    def generate(file = nil)
+      Derivation::Generate.new(self).call(file)
     end
 
     def upload(file = nil)
@@ -1025,7 +1025,7 @@ class Shrine
     private
 
     def local_response(env)
-      derivative = derivation.call
+      derivative = derivation.generate
 
       file_response(derivative, env)
     end
@@ -1055,7 +1055,7 @@ class Shrine
       uploaded_file = derivation.retrieve
 
       unless uploaded_file
-        derivative    = derivation.call
+        derivative    = derivation.generate
         uploaded_file = derivation.upload(derivative)
       end
 
@@ -1110,14 +1110,14 @@ class Shrine
     private
 
     def local_result
-      derivation.call
+      derivation.generate
     end
 
     def upload_result
       uploaded_file = derivation.retrieve
 
       unless uploaded_file
-        derivative    = derivation.call
+        derivative    = derivation.generate
         uploaded_file = derivation.upload(derivative)
 
         derivative.unlink
@@ -1127,7 +1127,7 @@ class Shrine
     end
   end
 
-  class Derivation::Call < Derivation::Command
+  class Derivation::Generate < Derivation::Command
     delegate :name, :args, :source,
              :download, :download_errors, :download_options,
              :include_uploaded_file
@@ -1206,7 +1206,7 @@ class Shrine
     delegate :upload_location, :upload_storage, :upload_options
 
     def call(derivative = nil)
-      derivative ||= derivation.call
+      derivative ||= derivation.generate
 
       uploader.upload derivative,
         location:       upload_location,

--- a/lib/shrine/plugins/derivation_endpoint.rb
+++ b/lib/shrine/plugins/derivation_endpoint.rb
@@ -677,6 +677,10 @@ class Shrine
       Derivation::Retrieve.new(self).call
     end
 
+    def delete
+      Derivation::Delete.new(self).call
+    end
+
     def self.options
       @options ||= {}
     end
@@ -1075,7 +1079,7 @@ class Shrine
   end
 
   class Derivation::Upload < Derivation::Command
-    delegate :upload_location, :upload_storage, :upload_options, :version
+    delegate :upload_location, :upload_storage, :upload_options
 
     def call(derivative = nil)
       derivative ||= derivation.call
@@ -1093,7 +1097,7 @@ class Shrine
   end
 
   class Derivation::Retrieve < Derivation::Command
-    delegate :upload_location, :upload_storage, :version
+    delegate :upload_location, :upload_storage
 
     def call
       if storage.exists?(upload_location)
@@ -1102,6 +1106,20 @@ class Shrine
           "id"      => upload_location,
         )
       end
+    end
+
+    private
+
+    def storage
+      shrine_class.find_storage(upload_storage)
+    end
+  end
+
+  class Derivation::Delete < Derivation::Command
+    delegate :upload_location, :upload_storage
+
+    def call
+      storage.delete(upload_location)
     end
 
     private

--- a/test/plugin/derivation_endpoint_test.rb
+++ b/test/plugin/derivation_endpoint_test.rb
@@ -304,6 +304,10 @@ describe Shrine::Plugins::DerivationEndpoint do
       response = app.get(derivation_url)
       assert_equal 200,  response.status
       assert_equal "12", response.headers["Content-Length"]
+
+      max_age = Integer(response.headers["Cache-Control"][/max-age=(\d+)/, 1])
+      assert_operator max_age, :<=, 100
+      assert_operator 0,       :<, max_age
     end
 
     it "returns 403 when link has expired" do

--- a/test/plugin/derivation_endpoint_test.rb
+++ b/test/plugin/derivation_endpoint_test.rb
@@ -726,9 +726,9 @@ describe Shrine::Plugins::DerivationEndpoint do
       end
     end
 
-    describe "#call" do
+    describe "#generate" do
       it "returns the derivative" do
-        tempfile = @uploaded_file.derivation(:gray).call
+        tempfile = @uploaded_file.derivation(:gray).generate
         assert_instance_of Tempfile, tempfile
         assert_equal "gray content", tempfile.read
       end
@@ -736,7 +736,7 @@ describe Shrine::Plugins::DerivationEndpoint do
       it "allows passing already downloaded file" do
         @shrine.derivation(:gray) { |file| file }
         @uploaded_file.expects(:download).never
-        result = @uploaded_file.derivation(:gray).call(file = Tempfile.new)
+        result = @uploaded_file.derivation(:gray).generate(file = Tempfile.new)
         assert_equal file, result
       end
 
@@ -752,16 +752,16 @@ describe Shrine::Plugins::DerivationEndpoint do
         end
 
         @uploaded_file = @uploader.upload(fakeio("original"))
-        @uploaded_file.derivation(:gray, "dark", "sepia").call
+        @uploaded_file.derivation(:gray, "dark", "sepia").generate
       end
 
       it "applies :download_options" do
         @shrine.plugin :derivation_endpoint, download_options: { foo: "foo" }
         @uploaded_file.expects(:download).with(foo: "foo").returns(Tempfile.new)
-        @uploaded_file.derivation(:gray).call
+        @uploaded_file.derivation(:gray).generate
 
         @uploaded_file.expects(:download).with(bar: "bar").returns(Tempfile.new)
-        @uploaded_file.derivation(:gray, download_options: { bar: "bar" }).call
+        @uploaded_file.derivation(:gray, download_options: { bar: "bar" }).generate
       end
 
       it "applies :include_uploaded_file" do
@@ -776,7 +776,7 @@ describe Shrine::Plugins::DerivationEndpoint do
         end
 
         @shrine.plugin :derivation_endpoint, include_uploaded_file: true
-        @uploaded_file.derivation(:gray, "dark").call
+        @uploaded_file.derivation(:gray, "dark").generate
 
         @shrine.derivation(:gray) do |file, *args|
           minitest.assert_instance_of Tempfile, file
@@ -785,7 +785,7 @@ describe Shrine::Plugins::DerivationEndpoint do
           Tempfile.new
         end
 
-        @uploaded_file.derivation(:gray, "dark", include_uploaded_file: false).call
+        @uploaded_file.derivation(:gray, "dark", include_uploaded_file: false).generate
       end
 
       it "applies :download" do
@@ -801,7 +801,7 @@ describe Shrine::Plugins::DerivationEndpoint do
 
         @shrine.plugin :derivation_endpoint, download: false
         @storage.expects(:open).never
-        @uploaded_file.derivation(:gray, "dark").call
+        @uploaded_file.derivation(:gray, "dark").generate
 
         @shrine.derivation(:gray) do |file, *args|
           minitest.assert_instance_of Tempfile, file
@@ -811,14 +811,14 @@ describe Shrine::Plugins::DerivationEndpoint do
         end
 
         @storage.expects(:open).returns(StringIO.new)
-        @uploaded_file.derivation(:gray, "dark", download: true).call
+        @uploaded_file.derivation(:gray, "dark", download: true).generate
       end
 
       it "raises SourceNotFound on error from :download_errors raised on downloading" do
         @shrine.plugin :derivation_endpoint, download_errors: [KeyError]
         @uploaded_file.delete
         assert_raises(Shrine::Derivation::SourceNotFound) do
-          @uploaded_file.derivation(:gray).call
+          @uploaded_file.derivation(:gray).generate
         end
       end
 
@@ -826,7 +826,7 @@ describe Shrine::Plugins::DerivationEndpoint do
         @shrine.plugin :derivation_endpoint, download_errors: [KeyError]
         @shrine.derivation(:gray) { raise KeyError }
         assert_raises(KeyError) do
-          @uploaded_file.derivation(:gray).call
+          @uploaded_file.derivation(:gray).generate
         end
       end
 
@@ -836,7 +836,7 @@ describe Shrine::Plugins::DerivationEndpoint do
           tempfile << "gray content"
           tempfile
         end
-        tempfile = @uploaded_file.derivation(:gray).call
+        tempfile = @uploaded_file.derivation(:gray).generate
         assert_instance_of Tempfile, tempfile
         assert_equal "gray content", tempfile.read
         assert_equal "gray content", File.read(tempfile.path)
@@ -851,7 +851,7 @@ describe Shrine::Plugins::DerivationEndpoint do
           file << "gray content"
           file
         end
-        file = @uploaded_file.derivation(:gray).call
+        file = @uploaded_file.derivation(:gray).generate
         assert_instance_of File, file
         assert_equal "gray content", file.read
         assert_equal "gray content", File.read(file.path)
@@ -866,7 +866,7 @@ describe Shrine::Plugins::DerivationEndpoint do
           File.write(path, "gray content")
           path
         end
-        file = @uploaded_file.derivation(:gray).call
+        file = @uploaded_file.derivation(:gray).generate
         assert_instance_of File, file
         assert_equal "gray content", file.read
         assert_equal "gray content", File.read(file.path)
@@ -882,7 +882,7 @@ describe Shrine::Plugins::DerivationEndpoint do
           pathname.write("gray content")
           pathname
         end
-        file = @uploaded_file.derivation(:gray).call
+        file = @uploaded_file.derivation(:gray).generate
         assert_instance_of File, file
         assert_equal "gray content", file.read
         assert_equal "gray content", File.read(file.path)
@@ -895,7 +895,7 @@ describe Shrine::Plugins::DerivationEndpoint do
         @shrine.derivation(:gray) { |file| StringIO.new }
 
         assert_raises(Shrine::Error) do
-          @uploaded_file.derivation(:gray, "dark").call
+          @uploaded_file.derivation(:gray, "dark").generate
         end
       end
     end

--- a/test/plugin/derivation_endpoint_test.rb
+++ b/test/plugin/derivation_endpoint_test.rb
@@ -989,6 +989,20 @@ describe Shrine::Plugins::DerivationEndpoint do
     end
   end
 
+  describe "Derivation#option" do
+    it "returns value of the specified plugin option" do
+      upload_location = @uploaded_file.derivation(:gray).option(:upload_location)
+      assert_equal "#{@uploaded_file.id}/gray", upload_location
+
+      @shrine.plugin :derivation_endpoint, version: 1
+      upload_location = @uploaded_file.derivation(:gray).option(:upload_location)
+      assert_equal "#{@uploaded_file.id}/gray-1", upload_location
+
+      upload_location = @uploaded_file.derivation(:gray, upload_location: "foo").option(:upload_location)
+      assert_equal "foo-1", upload_location
+    end
+  end
+
   it "merges new settings with previous" do
     @shrine.plugin :derivation_endpoint, type: "text/plain"
     @shrine.derivation(:gray) { "gray" }

--- a/test/plugin/derivation_endpoint_test.rb
+++ b/test/plugin/derivation_endpoint_test.rb
@@ -1,0 +1,788 @@
+require "test_helper"
+require "shrine/plugins/derivation_endpoint"
+require "rack/test_app"
+require "tempfile"
+require "stringio"
+
+describe Shrine::Plugins::DerivationEndpoint do
+  before do
+    @uploader = uploader { plugin :derivation_endpoint, secret_key: "secret" }
+    @shrine = @uploader.class
+    @uploaded_file = @uploader.upload(fakeio)
+    @storage = @uploader.storage
+
+    @shrine.derivation(:gray) do |file, type|
+      tempfile = Tempfile.new
+      tempfile << ["gray", *type, "content"].join(" ")
+      tempfile.rewind
+      tempfile
+    end
+  end
+
+  describe "UploadedFile#derivation_url" do
+    it "includes derivation name" do
+      derivation_url = @uploaded_file.derivation_url(:gray)
+      assert_match %r{^/gray/\w+\?}, derivation_url
+    end
+
+    it "includes derivation args" do
+      derivation_url = @uploaded_file.derivation_url(:gray, "dark")
+      assert_match %r{^/gray/dark/\w+\?}, derivation_url
+    end
+
+    it "applies :host" do
+      @shrine.plugin :derivation_endpoint, host: "https://example.com"
+      derivation_url = @uploaded_file.derivation_url(:gray)
+      assert_match %r{^https://example\.com/gray/\w+\?}, derivation_url
+
+      derivation_url = @uploaded_file.derivation_url(:gray, host: "https://other.com")
+      assert_match %r{^https://other\.com/gray/\w+\?}, derivation_url
+    end
+
+    it "applies :prefix" do
+      @shrine.plugin :derivation_endpoint, prefix: "foo/bar"
+      derivation_url = @uploaded_file.derivation_url(:gray)
+      assert_match %r{^/foo/bar/gray/\w+\?}, derivation_url
+
+      derivation_url = @uploaded_file.derivation_url(:gray, prefix: "baz")
+      assert_match %r{^/baz/gray/\w+\?}, derivation_url
+    end
+
+    it "applies :host and :prefix" do
+      @shrine.plugin :derivation_endpoint, prefix: "prefix", host: "https://example.com"
+      derivation_url = @uploaded_file.derivation_url(:gray)
+      assert_match %r{^https://example\.com/prefix/gray/\w+\?}, derivation_url
+    end
+
+    it "applies :expires_in" do
+      derivation_url = @uploaded_file.derivation_url(:gray)
+      refute_match %r{expires_at=}, derivation_url
+
+      @shrine.plugin :derivation_endpoint, expires_in: 10
+      derivation_url = @uploaded_file.derivation_url(:gray)
+      assert_match %r{expires_at=\d+}, derivation_url
+      expires_at = Integer(derivation_url[/expires_at=(\d+)/, 1])
+      assert_operator Time.now + 10,       :>=, Time.at(expires_at)
+      assert_operator Time.at(expires_at), :>=, Time.now
+
+      @shrine.plugin :derivation_endpoint, expires_in: -> (context) { 10 }
+      derivation_url = @uploaded_file.derivation_url(:gray)
+      assert_match %r{expires_at=\d+}, derivation_url
+      expires_at = Integer(derivation_url[/expires_at=(\d+)/, 1])
+      assert_operator Time.now + 10,       :>=, Time.at(expires_at)
+      assert_operator Time.at(expires_at), :>=, Time.now
+
+      derivation_url = @uploaded_file.derivation_url(:gray, expires_in: 5)
+      assert_match %r{expires_at=(\d+)}, derivation_url
+      expires_at = Integer(derivation_url[/expires_at=(\d+)/, 1])
+      assert_operator Time.now + 5,        :>=, Time.at(expires_at)
+      assert_operator Time.at(expires_at), :>=, Time.now
+    end
+
+    it "applies :version" do
+      derivation_url = @uploaded_file.derivation_url(:gray)
+      refute_match %r{version=}, derivation_url
+
+      @shrine.plugin :derivation_endpoint, version: 1
+      derivation_url = @uploaded_file.derivation_url(:gray)
+      assert_match %r{version=1}, derivation_url
+
+      @shrine.plugin :derivation_endpoint, version: -> (context) { 1 }
+      derivation_url = @uploaded_file.derivation_url(:gray)
+      assert_match %r{version=1}, derivation_url
+
+      derivation_url = @uploaded_file.derivation_url(:gray, version: 2)
+      assert_match %r{version=2}, derivation_url
+    end
+
+    it "applies :type" do
+      derivation_url = @uploaded_file.derivation_url(:gray)
+      refute_match %r{type=}, derivation_url
+
+      @shrine.plugin :derivation_endpoint, type: "text/plain"
+      derivation_url = @uploaded_file.derivation_url(:gray)
+      refute_match %r{type=}, derivation_url
+
+      derivation_url = @uploaded_file.derivation_url(:gray, type: "text/csv")
+      assert_match %r{type=text%2Fcsv}, derivation_url
+    end
+
+    it "applies :filename" do
+      derivation_url = @uploaded_file.derivation_url(:gray)
+      refute_match %r{filename=}, derivation_url
+
+      @shrine.plugin :derivation_endpoint, filename: "custom.txt"
+      derivation_url = @uploaded_file.derivation_url(:gray)
+      refute_match %r{filename=}, derivation_url
+
+      derivation_url = @uploaded_file.derivation_url(:gray, filename: "custom.txt")
+      assert_match %r{filename=custom\.txt}, derivation_url
+    end
+
+    it "applies :disposition" do
+      derivation_url = @uploaded_file.derivation_url(:gray)
+      refute_match %r{disposition=}, derivation_url
+
+      @shrine.plugin :derivation_endpoint, disposition: "attachment"
+      derivation_url = @uploaded_file.derivation_url(:gray)
+      refute_match %r{disposition=}, derivation_url
+
+      derivation_url = @uploaded_file.derivation_url(:gray, disposition: "attachment")
+      assert_match %r{disposition=attachment}, derivation_url
+    end
+
+    it "applies :metadata" do
+      @uploaded_file.metadata.merge!("foo" => "bar", "baz" => "quux")
+
+      derivation_url = @uploaded_file.derivation_url(:gray)
+      serialized_file = URI(derivation_url).path[/\w+$/]
+      uploaded_file = @shrine::UploadedFile.urlsafe_load(serialized_file)
+      assert_equal Hash.new, uploaded_file.metadata
+
+      @shrine.plugin :derivation_endpoint, metadata: ["foo"]
+      derivation_url = @uploaded_file.derivation_url(:gray)
+      serialized_file = URI(derivation_url).path[/\w+$/]
+      uploaded_file = @shrine::UploadedFile.urlsafe_load(serialized_file)
+      assert_equal Hash["foo" => "bar"], uploaded_file.metadata
+
+      derivation_url = @uploaded_file.derivation_url(:gray, metadata: ["baz"])
+      serialized_file = URI(derivation_url).path[/\w+$/]
+      uploaded_file = @shrine::UploadedFile.urlsafe_load(serialized_file)
+      assert_equal Hash["baz" => "quux"], uploaded_file.metadata
+    end
+
+    it "escapes path and query params" do
+      derivation_url = @uploaded_file.derivation_url(:gray, "foo bar", filename: "foo bar")
+      assert_match /gray\/foo%20bar/,    URI(derivation_url).path
+      assert_match /filename=foo\+bar/, URI(derivation_url).query
+    end
+
+    it "generates signature from derivation name, args, params, and secret key" do
+      signatures = []
+
+      derivation_url = @uploaded_file.derivation_url(:foo)
+      signatures << derivation_url[/signature=(\w+)/, 1]
+
+      derivation_url = @uploaded_file.derivation_url(:bar)
+      signatures << derivation_url[/signature=(\w+)/, 1]
+
+      derivation_url = @uploaded_file.derivation_url(:foo, "foo")
+      signatures << derivation_url[/signature=(\w+)/, 1]
+
+      derivation_url = @uploaded_file.derivation_url(:foo, "bar")
+      signatures << derivation_url[/signature=(\w+)/, 1]
+
+      derivation_url = @uploaded_file.derivation_url(:foo, expires_in: 10)
+      signatures << derivation_url[/signature=(\w+)/, 1]
+
+      derivation_url = @uploaded_file.derivation_url(:foo, expires_in: 20)
+      signatures << derivation_url[/signature=(\w+)/, 1]
+
+      @shrine.plugin :derivation_endpoint, secret_key: "other_secret"
+      derivation_url = @uploaded_file.derivation_url(:foo)
+      signatures << derivation_url[/signature=(\w+)/, 1]
+
+      assert_equal signatures, signatures.uniq
+    end
+
+    it "doesn't require the derivation to exist" do
+      derivation_url = @uploaded_file.derivation_url(:other)
+      assert_match %r{/other/\w+\?}, derivation_url
+    end
+  end
+
+  describe "Shrine.derivation_endpoint" do
+    def app(*args)
+      Rack::TestApp.wrap(Rack::Lint.new(@shrine.derivation_endpoint(*args)))
+    end
+
+    it "generates correct derivation response" do
+      derivation_url = @uploaded_file.derivation_url(:gray, "dark")
+      response = app.get(derivation_url)
+      assert_equal 200,                        response.status
+      assert_equal "gray dark content",        response.body_binary
+      assert_equal "17",                       response.headers["Content-Length"]
+      assert_match "application/octet-stream", response.headers["Content-Type"]
+    end
+
+    it "handles ranged requests" do
+      derivation_url = @uploaded_file.derivation_url(:gray)
+      response = app.get(derivation_url, headers: { "Range" => "bytes=0-3" })
+      assert_equal 206,                        response.status
+      assert_equal "gray",                     response.body_binary
+      assert_equal "4",                        response.headers["Content-Length"]
+      assert_equal "bytes 0-3/12",             response.headers["Content-Range"]
+    end
+
+    it "applies plugin options" do
+      @shrine.plugin :derivation_endpoint, disposition: "attachment"
+      derivation_url = @uploaded_file.derivation_url(:gray)
+      response = app.get(derivation_url)
+      assert_equal 200,            response.status
+      assert_match "attachment; ", response.headers["Content-Disposition"]
+    end
+
+    it "applies app options" do
+      @shrine.plugin :derivation_endpoint, disposition: "inline"
+      derivation_url = @uploaded_file.derivation_url(:gray)
+      response = app(disposition: "attachment").get(derivation_url)
+      assert_equal 200,            response.status
+      assert_match "attachment; ", response.headers["Content-Disposition"]
+    end
+
+    it "applies 'type' param" do
+      @shrine.plugin :derivation_endpoint, type: "text/plain"
+      derivation_url = @uploaded_file.derivation_url(:gray, type: "text/csv")
+      response = app(type: "text/plain").get(derivation_url)
+      assert_equal 200,        response.status
+      assert_equal "text/csv", response.headers["Content-Type"]
+    end
+
+    it "applies 'disposition' param" do
+      @shrine.plugin :derivation_endpoint, disposition: "inline"
+      derivation_url = @uploaded_file.derivation_url(:gray, disposition: "attachment")
+      response = app(disposition: "inline").get(derivation_url)
+      assert_equal 200,            response.status
+      assert_match "attachment; ", response.headers["Content-Disposition"]
+    end
+
+    it "applies 'filename' param" do
+      @shrine.plugin :derivation_endpoint, filename: "default"
+      derivation_url = @uploaded_file.derivation_url(:gray, filename: "custom")
+      response = app(filename: "default").get(derivation_url)
+      assert_equal 200,                   response.status
+      assert_match "filename=\"custom\"", response.headers["Content-Disposition"]
+    end
+
+    it "returns Cache-Control header for successful responses" do
+      derivation_url = @uploaded_file.derivation_url(:gray)
+      response = app.get(derivation_url)
+      assert_equal 200,                        response.status
+      assert_equal "public, max-age=31536000", response.headers["Cache-Control"]
+
+      derivation_url = @uploaded_file.derivation_url(:gray)
+      response = app.get(derivation_url, headers: { "Range" => "bytes=0-3" })
+      assert_equal 206,                        response.status
+      assert_equal "public, max-age=31536000", response.headers["Cache-Control"]
+
+      @shrine.plugin :derivation_endpoint, upload: true, upload_redirect: true
+      derivation_url = @uploaded_file.derivation_url(:gray)
+      response = app.get(derivation_url)
+      assert_equal 302, response.status
+      assert_nil response.headers["Cache-Control"]
+    end
+
+    it "returns 404 on unknown derivation" do
+      derivation_url = @uploaded_file.derivation_url(:nonexistent)
+      response = app.get(derivation_url)
+      assert_equal 404,                              response.status
+      assert_match "Unknown derivation",             response.body_binary
+      assert_equal response.body_binary.length.to_s, response.headers["Content-Length"]
+    end
+
+    it "propagates download errors" do
+      @shrine.plugin :derivation_endpoint
+      derivation_url = @uploaded_file.derivation_url(:gray)
+      @uploaded_file.delete
+      assert_raises(KeyError) do
+        app.get(derivation_url)
+      end
+    end
+
+    it "returns 404 when error from :download_errors is raised" do
+      @shrine.plugin :derivation_endpoint, download_errors: [KeyError]
+      @uploaded_file.delete
+      derivation_url = @uploaded_file.derivation_url(:gray)
+      response = app.get(derivation_url)
+      assert_equal 404,                              response.status
+      assert_match "Source file not found",          response.body_binary
+      assert_equal response.body_binary.length.to_s, response.headers["Content-Length"]
+    end
+
+    it "proceeds when expiring link has not expired" do
+      derivation_url = @uploaded_file.derivation_url(:gray, expires_in: 100)
+      response = app.get(derivation_url)
+      assert_equal 200,  response.status
+      assert_equal "12", response.headers["Content-Length"]
+    end
+
+    it "returns 403 when link has expired" do
+      derivation_url = @uploaded_file.derivation_url(:gray, expires_in: -1)
+      response = app.get(derivation_url)
+      assert_equal 403,                              response.status
+      assert_match "Request has expired",            response.body_binary
+      assert_equal response.body_binary.length.to_s, response.headers["Content-Length"]
+    end
+
+    it "returns 403 on invalid signature" do
+      derivation_url = @uploaded_file.derivation_url(:gray).sub(/\w+$/, "foo")
+      response = app.get(derivation_url)
+      assert_equal 403,                              response.status
+      assert_match "signature doesn't match",        response.body_binary
+      assert_equal response.body_binary.length.to_s, response.headers["Content-Length"]
+    end
+
+    it "returns 403 on missing signature" do
+      derivation_url = @uploaded_file.derivation_url(:gray).sub(/signature=\w+$/, "")
+      response = app.get(derivation_url)
+      assert_equal 403,                              response.status
+      assert_match "Signature is missing",           response.body_binary
+      assert_equal response.body_binary.length.to_s, response.headers["Content-Length"]
+    end
+
+    it "includes request params when calculating signature" do
+      derivation_url = @uploaded_file.derivation_url(:gray) + "&foo=bar"
+      response = app.get(derivation_url)
+      assert_equal 403,                              response.status
+      assert_match "signature doesn't match",        response.body_binary
+      assert_equal response.body_binary.length.to_s, response.headers["Content-Length"]
+    end
+
+    it "accepts HEAD requests" do
+      derivation_url = @uploaded_file.derivation_url(:gray)
+      response = app.head(derivation_url)
+      assert_equal 200,                        response.status
+      assert_equal "application/octet-stream", response.headers["Content-Type"]
+      assert_equal "12",                       response.headers["Content-Length"]
+    end
+
+    it "returns 405 on invalid request method" do
+      derivation_url = @uploaded_file.derivation_url(:gray)
+      response = app.post(derivation_url)
+      assert_equal 405,                              response.status
+      assert_equal "Method not allowed",             response.body_binary
+      assert_equal response.body_binary.length.to_s, response.headers["Content-Length"]
+    end
+  end
+
+  describe "Shrine.derivation_response" do
+    it "works in the main app" do
+      @shrine.plugin :derivation_endpoint, prefix: "derivations"
+
+      derivation_url = @uploaded_file.derivation_url(:gray)
+
+      env = {
+        "REQUEST_METHOD" => "GET",
+        "SCRIPT_NAME"    => "",
+        "PATH_INFO"      => URI(derivation_url).path,
+        "QUERY_STRING"   => URI(derivation_url).query,
+        "rack.input"     => StringIO.new,
+      }
+
+      status, headers, body = @shrine.derivation_response(env)
+
+      assert_equal 200,            status
+      assert_equal "12",           headers["Content-Length"]
+      assert_equal "gray content", body.enum_for(:each).to_a.join
+
+      assert_equal "",                       env["SCRIPT_NAME"]
+      assert_equal URI(derivation_url).path, env["PATH_INFO"]
+    end
+
+    it "works in a mounted app" do
+      @shrine.plugin :derivation_endpoint, prefix: "derivations"
+
+      derivation_url = @uploaded_file.derivation_url(:gray)
+
+      env = {
+        "REQUEST_METHOD" => "GET",
+        "SCRIPT_NAME"    => "/foo",
+        "PATH_INFO"      => URI(derivation_url).path,
+        "QUERY_STRING"   => URI(derivation_url).query,
+        "rack.input"     => StringIO.new,
+      }
+
+      status, headers, body = @shrine.derivation_response(env)
+
+      assert_equal 200,    status
+      assert_equal "/foo", env["SCRIPT_NAME"]
+    end
+
+    it "accepts additional options" do
+      @shrine.plugin :derivation_endpoint, prefix: "derivations"
+
+      derivation_url = @uploaded_file.derivation_url(:gray)
+
+      env = {
+        "REQUEST_METHOD" => "GET",
+        "SCRIPT_NAME"    => "",
+        "PATH_INFO"      => URI(derivation_url).path,
+        "QUERY_STRING"   => URI(derivation_url).query,
+        "rack.input"     => StringIO.new,
+      }
+
+      status, headers, body = @shrine.derivation_response(env, type: "text/plain")
+
+      assert_equal 200,          status
+      assert_equal "text/plain", headers["Content-Type"]
+    end
+
+    it "fails when request path doesn't start with prefix" do
+      @shrine.plugin :derivation_endpoint, prefix: "derivations"
+
+      derivation_url = @uploaded_file.derivation_url(:gray, prefix: "other")
+
+      env = {
+        "REQUEST_METHOD" => "GET",
+        "SCRIPT_NAME"    => "",
+        "PATH_INFO"      => URI(derivation_url).path,
+        "QUERY_STRING"   => URI(derivation_url).query,
+        "rack.input"     => StringIO.new,
+      }
+
+      assert_raises(Shrine::Error) do
+        @shrine.derivation_response(env)
+      end
+    end
+  end
+
+  describe "UploadedFile#derivation_response" do
+    describe "without upload" do
+      it "returns derivation response" do
+        response = @uploaded_file.derivation_response(:gray, env: {})
+
+        assert_equal 200, response[0]
+
+        content_disposition = ContentDisposition.inline("gray-#{@uploaded_file.id}")
+
+        assert_equal "12",                       response[1]["Content-Length"]
+        assert_equal content_disposition,        response[1]["Content-Disposition"]
+        assert_equal "application/octet-stream", response[1]["Content-Type"]
+        assert_equal "bytes",                    response[1]["Accept-Ranges"]
+
+        assert_equal "gray content", response[2].enum_for(:each).to_a.join
+      end
+
+      it "adds derivation arguments to filename" do
+        response = @uploaded_file.derivation_response(:gray, "dark", env: {})
+
+        content_disposition = ContentDisposition.inline("gray-dark-#{@uploaded_file.id}")
+
+        assert_equal content_disposition, response[1]["Content-Disposition"]
+      end
+
+      it "uses derivation extension for type and filename" do
+        @shrine.derivation(:gray) { |file| Tempfile.new(["derivation", ".txt"]) }
+
+        response = @uploaded_file.derivation_response(:gray, env: {})
+
+        content_disposition = ContentDisposition.inline("gray-#{@uploaded_file.id}.txt")
+
+        assert_equal content_disposition, response[1]["Content-Disposition"]
+        assert_equal "text/plain",        response[1]["Content-Type"]
+      end
+
+      it "doesn't use derivation extension if filename already has it" do
+        @shrine.derivation(:gray) { |file| Tempfile.new(["derivation", ".txt"]) }
+
+        response = @uploaded_file.derivation_response(:gray, env: {}, filename: "export.csv")
+
+        content_disposition = ContentDisposition.inline("export.csv")
+
+        assert_equal content_disposition, response[1]["Content-Disposition"]
+      end
+
+      it "applies :type" do
+        @shrine.plugin :derivation_endpoint, type: "text/plain"
+        response = @uploaded_file.derivation_response(:gray, env: {})
+        assert_equal "text/plain", response[1]["Content-Type"]
+
+        @shrine.plugin :derivation_endpoint, type: -> (context) { "text/plain" }
+        response = @uploaded_file.derivation_response(:gray, env: {})
+        assert_equal "text/plain", response[1]["Content-Type"]
+
+        response = @uploaded_file.derivation_response(:gray, env: {}, type: "text/csv")
+        assert_equal "text/csv", response[1]["Content-Type"]
+
+        response = @uploaded_file.derivation_response(:gray, env: {}, type: -> (context) { "text/csv" })
+        assert_equal "text/csv", response[1]["Content-Type"]
+      end
+
+      it "applies :disposition" do
+        @shrine.plugin :derivation_endpoint, disposition: "attachment"
+        response = @uploaded_file.derivation_response(:gray, env: {})
+        assert_match "attachment; ", response[1]["Content-Disposition"]
+
+        @shrine.plugin :derivation_endpoint, disposition: -> (context) { "attachment" }
+        response = @uploaded_file.derivation_response(:gray, env: {})
+        assert_match "attachment; ", response[1]["Content-Disposition"]
+
+        response = @uploaded_file.derivation_response(:gray, env: {}, disposition: "inline")
+        assert_match "inline; ", response[1]["Content-Disposition"]
+
+        response = @uploaded_file.derivation_response(:gray, env: {}, disposition: -> (context) { "inline" })
+        assert_match "inline; ", response[1]["Content-Disposition"]
+      end
+
+      it "applies :filename" do
+        @shrine.plugin :derivation_endpoint, filename: "one"
+        response = @uploaded_file.derivation_response(:gray, env: {})
+        assert_match "inline; filename=\"one\"", response[1]["Content-Disposition"]
+
+        @shrine.plugin :derivation_endpoint, filename: -> (context) { "one" }
+        response = @uploaded_file.derivation_response(:gray, env: {})
+        assert_match "inline; filename=\"one\"", response[1]["Content-Disposition"]
+
+        response = @uploaded_file.derivation_response(:gray, env: {}, filename: "two")
+        assert_match "inline; filename=\"two\"", response[1]["Content-Disposition"]
+
+        response = @uploaded_file.derivation_response(:gray, env: {}, filename: -> (context) { "two" })
+        assert_match "inline; filename=\"two\"", response[1]["Content-Disposition"]
+      end
+
+      it "handles Range requests" do
+        response = @uploaded_file.derivation_response(:gray, env: {
+          "HTTP_RANGE" => "bytes=0-3",
+        })
+
+        assert_equal 206,            response[0]
+        assert_equal "bytes 0-3/12", response[1]["Content-Range"]
+        assert_equal "bytes",        response[1]["Accept-Ranges"]
+        assert_equal "gray",         response[2].enum_for(:each).to_a.join
+      end
+
+      it "raises SourceNotFound on error from :download_errors raised on downloading" do
+        @shrine.plugin :derivation_endpoint, download_errors: [KeyError]
+        @uploaded_file.delete
+        assert_raises(Shrine::Plugins::DerivationEndpoint::SourceNotFound) do
+          @uploaded_file.derivation_response(:gray, env: {})
+        end
+      end
+
+      it "propagates errors from :download_errors raises in derivation block" do
+        @shrine.plugin :derivation_endpoint, download_errors: [KeyError]
+        @shrine.derivation(:gray) { raise KeyError }
+        assert_raises(KeyError) do
+          @uploaded_file.derivation_response(:gray, env: {})
+        end
+      end
+    end
+
+    describe "with upload" do
+      before do
+        @shrine.plugin :derivation_endpoint, upload: true
+      end
+
+      it "returns local file response the first time" do
+        response = @uploaded_file.derivation_response(:gray, env: {})
+
+        assert_equal 200, response[0]
+
+        content_disposition = ContentDisposition.inline("gray-#{@uploaded_file.id}")
+
+        assert_equal "12",                       response[1]["Content-Length"]
+        assert_equal content_disposition,        response[1]["Content-Disposition"]
+        assert_equal "application/octet-stream", response[1]["Content-Type"]
+        assert_equal "bytes",                    response[1]["Accept-Ranges"]
+
+        assert_equal "gray content", response[2].enum_for(:each).to_a.join
+      end
+
+      it "returns uploaded file response the second time" do
+        @uploaded_file.derivation_response(:gray, "dark", env: {})
+        @shrine.derivation(:gray) { fail "this should not be called anymore" }
+
+        response = @uploaded_file.derivation_response(:gray, "dark", env: {})
+
+        assert_equal 200, response[0]
+
+        content_disposition = ContentDisposition.inline("gray-dark-#{@uploaded_file.id}")
+
+        assert_equal "17",                       response[1]["Content-Length"]
+        assert_equal content_disposition,        response[1]["Content-Disposition"]
+        assert_equal "application/octet-stream", response[1]["Content-Type"]
+        assert_equal "bytes",                    response[1]["Accept-Ranges"]
+
+        assert_equal "gray dark content", response[2].enum_for(:each).to_a.join
+      end
+
+      it "uploads the derivation the first time" do
+        @uploaded_file.derivation_response(:gray, "dark", env: {})
+
+        assert @storage.exists?("#{@uploaded_file.id}/gray-dark")
+        assert_equal "gray dark content", @storage.open("#{@uploaded_file.id}/gray-dark").read
+      end
+
+      it "doesn't upload the derivation the second time" do
+        @uploaded_file.derivation_response(:gray, "dark", env: {})
+        @storage.expects(:upload).never
+        @uploaded_file.derivation_response(:gray, "dark", env: {})
+      end
+
+      it "excludes original extension from default upload location" do
+        @uploaded_file = @uploader.upload(fakeio, location: "foo.jpg")
+        @uploaded_file.derivation_response(:gray, "dark", env: {})
+
+        assert @storage.exists?("foo/gray-dark")
+        assert_equal "gray dark content", @storage.open("foo/gray-dark").read
+      end
+
+      it "handles Range requests" do
+        @uploaded_file.derivation_response(:gray, env: {})
+        response = @uploaded_file.derivation_response(:gray, env: {
+          "HTTP_RANGE" => "bytes=0-3",
+        })
+
+        assert_equal 206,            response[0]
+        assert_equal "bytes 0-3/12", response[1]["Content-Range"]
+        assert_equal "bytes",        response[1]["Accept-Ranges"]
+        assert_equal "gray",         response[2].enum_for(:each).to_a.join
+      end
+
+      it "applies :upload_options" do
+        @shrine.plugin :derivation_endpoint, upload_options: { foo: "foo" }
+        @storage.expects(:upload).with { |*, **options| options[:foo] == "foo" }
+        @uploaded_file.derivation_response(:gray, env: {})
+
+        @storage.expects(:upload).with { |*, **options| options[:bar] == "bar" }
+        @uploaded_file.derivation_response(:gray, env: {}, upload_options: { bar: "bar" })
+      end
+
+      it "applies :upload_location" do
+        @shrine.plugin :derivation_endpoint, upload_location: -> (context) { "foo" }
+        @uploaded_file.derivation_response(:gray, env: {})
+        assert @storage.exists?("foo")
+        assert_equal "gray content", @storage.open("foo").read
+
+        @uploaded_file.derivation_response(:gray, env: {}, upload_location: -> (context) { "bar" })
+        assert @storage.exists?("bar")
+        assert_equal "gray content", @storage.open("bar").read
+      end
+
+      it "appends :version to :upload_location" do
+        @shrine.plugin :derivation_endpoint, version: 1
+        @uploaded_file.derivation_response(:gray, env: {})
+        assert @storage.exists?("#{@uploaded_file.id}/gray-1")
+        assert_equal "gray content", @storage.open("#{@uploaded_file.id}/gray-1").read
+
+        @shrine.plugin :derivation_endpoint, version: 1, upload_location: -> (context) { "foo.txt" }
+        @uploaded_file.derivation_response(:gray, env: {})
+        assert @storage.exists?("foo-1.txt")
+        assert_equal "gray content", @storage.open("foo-1.txt").read
+      end
+
+      it "applies :upload_storage" do
+        @shrine.plugin :derivation_endpoint, upload_storage: :store
+
+        @uploaded_file.derivation_response(:gray, env: {})
+
+        assert @shrine.storages[:store].exists?("#{@uploaded_file.id}/gray")
+        assert_equal "gray content", @shrine.storages[:store].open("#{@uploaded_file.id}/gray").read
+
+        @shrine.storages[:store].expects(:upload).never
+
+        response = @uploaded_file.derivation_response(:gray, env: {})
+
+        assert_equal "gray content", response[2].enum_for(:each).to_a.join
+      end
+
+      it "applies :upload_redirect" do
+        @shrine.plugin :derivation_endpoint, upload_redirect: true
+        response = @uploaded_file.derivation_response(:gray, env: {})
+        assert_equal 302,                                       response[0]
+        assert_equal @storage.url("#{@uploaded_file.id}/gray"), response[1]["Location"]
+
+        response = @uploaded_file.derivation_response(:gray, env: {}, upload_redirect: true)
+        assert_equal 302,                                       response[0]
+        assert_equal @storage.url("#{@uploaded_file.id}/gray"), response[1]["Location"]
+      end
+
+      it "applies :upload_redirect_url_options" do
+        @shrine.plugin :derivation_endpoint, upload_redirect: true, upload_redirect_url_options: { foo: "foo" }
+        @storage.expects(:url).with("#{@uploaded_file.id}/gray", foo: "foo").returns("foo")
+        response = @uploaded_file.derivation_response(:gray, env: {})
+        assert_equal 302,   response[0]
+        assert_equal "foo", response[1]["Location"]
+
+        @storage.expects(:url).with("#{@uploaded_file.id}/gray", bar: "bar").returns("bar")
+        response = @uploaded_file.derivation_response(:gray, env: {}, upload_redirect_url_options: { bar: "bar" })
+        assert_equal 302,   response[0]
+        assert_equal "bar", response[1]["Location"]
+      end
+    end
+
+    it "passes downloaded file and derivation arguments for processing" do
+      @shrine.derivation(:gray) do |file, *args|
+        tempfile = Tempfile.new
+        tempfile.write [file.class, file.read, *args].join("-")
+        tempfile.open
+      end
+
+      @uploaded_file = @uploader.upload(fakeio("original"))
+      response = @uploaded_file.derivation_response(:gray, "dark", env: {})
+
+      assert_equal "Tempfile-original-dark", response[2].enum_for(:each).to_a.join
+    end
+
+    it "applies :download_options" do
+      @shrine.plugin :derivation_endpoint, download_options: { foo: "foo" }
+      @uploaded_file.expects(:download).with(foo: "foo").returns(Tempfile.new)
+      @uploaded_file.derivation_response(:gray, env: {})
+
+      @uploaded_file.expects(:download).with(bar: "bar").returns(Tempfile.new)
+      @uploaded_file.derivation_response(:gray, env: {}, download_options: { bar: "bar" })
+    end
+
+    it "applies :include_uploaded_file" do
+      @shrine.derivation(:gray) do |file, uploaded_file|
+        tempfile = Tempfile.new
+        tempfile.write "#{file.class}-#{uploaded_file.class.superclass}"
+        tempfile.open
+      end
+
+      @shrine.plugin :derivation_endpoint, include_uploaded_file: true
+      response = @uploaded_file.derivation_response(:gray, env: {})
+      assert_equal "Tempfile-Shrine::UploadedFile", response[2].enum_for(:each).to_a.join
+
+      response = @uploaded_file.derivation_response(:gray, env: {}, include_uploaded_file: true)
+      assert_equal "Tempfile-Shrine::UploadedFile", response[2].enum_for(:each).to_a.join
+    end
+
+    it "applies :download" do
+      @shrine.derivation(:gray) do |uploaded_file|
+        tempfile = Tempfile.new
+        tempfile.write "#{uploaded_file.class.superclass}-#{uploaded_file.opened?}"
+        tempfile.open
+      end
+
+      @shrine.plugin :derivation_endpoint, download: false
+      @uploaded_file.expects(:download).never
+      response = @uploaded_file.derivation_response(:gray, env: {})
+      assert_equal "Shrine::UploadedFile-false", response[2].enum_for(:each).to_a.join
+
+      @uploaded_file.expects(:download).never
+      response = @uploaded_file.derivation_response(:gray, env: {}, download: false)
+      assert_equal "Shrine::UploadedFile-false", response[2].enum_for(:each).to_a.join
+    end
+
+    it "doesn't include Cache-Control header" do
+      response = @uploaded_file.derivation_response(:gray, env: {})
+      assert_nil response[1]["Cache-Control"]
+    end
+
+    it "fails when derivation isn't a File object" do
+      @shrine.derivation(:gray) { |file| StringIO.new }
+
+      assert_raises(Shrine::Error) do
+        @uploaded_file.derivation_response(:gray, "dark", env: {})
+      end
+    end
+  end
+
+  it "merges new settings with previous" do
+    @shrine.plugin :derivation_endpoint, type: "text/plain"
+    @shrine.derivation(:gray) { "gray" }
+
+    @shrine.plugin :derivation_endpoint, disposition: "attachment"
+
+    assert_equal "gray",       @shrine.derivations.fetch(:gray).call
+    assert_equal "text/plain", @shrine.derivation_options.fetch(:type)
+    assert_equal "attachment", @shrine.derivation_options.fetch(:disposition)
+  end
+
+  it "requires the :secret_key option" do
+    assert_raises(Shrine::Error) do
+      @shrine.plugin :derivation_endpoint, secret_key: nil
+    end
+  end
+end

--- a/test/plugin/derivation_endpoint_test.rb
+++ b/test/plugin/derivation_endpoint_test.rb
@@ -933,7 +933,7 @@ describe Shrine::Plugins::DerivationEndpoint do
     it "raises SourceNotFound on error from :download_errors raised on downloading" do
       @shrine.plugin :derivation_endpoint, download_errors: [KeyError]
       @uploaded_file.delete
-      assert_raises(Shrine::Plugins::DerivationEndpoint::SourceNotFound) do
+      assert_raises(Shrine::Derivation::SourceNotFound) do
         @uploaded_file.derivation(:gray).call
       end
     end

--- a/test/plugin/derivation_endpoint_test.rb
+++ b/test/plugin/derivation_endpoint_test.rb
@@ -893,9 +893,15 @@ describe Shrine::Plugins::DerivationEndpoint do
 
       it "fails when derivative isn't a File object" do
         @shrine.derivation(:gray) { |file| StringIO.new }
-
         assert_raises(Shrine::Error) do
           @uploaded_file.derivation(:gray, "dark").generate
+        end
+      end
+
+      it "raises NotFound when derivation was not found" do
+        derivation = @uploaded_file.derivation(:unknown)
+        assert_raises(Shrine::Derivation::NotFound) do
+          derivation.generate
         end
       end
     end

--- a/www/_data/plugins.yml
+++ b/www/_data/plugins.yml
@@ -52,6 +52,10 @@ Model:
 
 Rack:
   -
+    name: derivation_endpoint
+    path: DerivationEndpoint.html
+    description: Provides a Rack application for processing uploaded files on-the-fly.
+  -
     name: direct_upload
     path: DirectUpload.html
     description: "[OBSOLETE] Use upload_endpoint and presign_endpoint plugins instead."


### PR DESCRIPTION
This pull request brings on-the-fly processing feature to Shrine in the form of a new `derivation_endpoint` plugin, similar to what Active Storage, Refile, and Dragonfly have. This can be used as an alternative to `processing`/`versions` plugins or together.

The reason it's named "*derivation* endpoint" is because we found that "derivation" most closely resembles the result – something that's *derived* from a source file. Btw, the existing `versions` plugin will be getting rewritten soon into a `derivatives` plugin.

## Usage

First we load the plugin with a secret key and a path prefix to which the endpoint will be mounted:

```rb
class ImageUploader < Shrine
  plugin :derivation_endpoint,
    secret_key: "<my-secret-key>",
    prefix:     "derivations/image"
end
```

And mount a derivation endpoint for our uploader into our router:

```rb
# config/router.rb (Rails)
Rails.application.routes.draw do
  mount ImageUploader.derivation_endpoint => "/derivations/image"
end

# OR

# config.ru (Rack)
map "/derivations/image" do
  run ImageUploader.derivation_endpoint
end
```

We then create a definition for derivations we want to generate:

```rb
require "image_processing/mini_magick"

class ImageUploader < Shrine
  derivation :thumbnail do |file, width, height|
    ImageProcessing::MiniMagick
      .source(file)
      .resize_to_limit!(width.to_i, height.to_i)
  end
end
```

Now we can call `#derivation_url` on an attached file, and it will return a URL to the derivative (which will be lazily generated when that URL is requested):

```rb
photo.image.derivation_url(:thumbnail, "600", "400")
#=> "/derivations/image/thumbnail/600/400/eyJmZvbyIb3JhZ2UiOiJzdG9yZSJ9?signature=..."
```

## How it works

The URL is composed of several parts:

```
/  derivations/image  /  thumbnail  /  600/400  /  eyJmZvbyIb3JhZ2UiOiJzdG9yZSJ9  ?  signature=...
  └──── prefix ─────┘  └── name ──┘  └─ args ─┘  └── serialized original file ──┘
```

When a derivation endpoint receives the request, it extracts derivation name, arguments, and original uploaded file from that URL. It then downloads the original uploaded file and calls the derivation block of the corresponding name with the downloaded file and derivation arguments. The result of the derivation block is then returned in the response.

URLs are signed with the `:secret_key`, which means only the server can generate a valid derivation URLs. This disables an attacker to tweak derivation arguments to DoS your server, preventing that attack vector.

## Comparison with Active Storage / Refile / Dragonfly

Shrine's `derivation_endpoint` differs from Active Storage and Dragonfly in the sense that processing steps aren't encoded in the URL. Also, AFAIK Active Storage currently doesn't support custom processors, so you cannot use something like [image_optim](https://github.com/toy/image_optim) in the processing pipeline.

For me the biggest improvement is that the behaviour of the derivation endpoint is highly configurable. Dragonfly & Refile always serve the processed file though the app, while Active Storage always uploads the processed file and redirects to it. Shrine's `derivation_endpoint` will serve processed files through the app only by default, but can be set to also upload them, or both upload them and redirect to them.

To illustrate, when Active Storage with S3 service, AS will redirect to expiring URLs, which means CDNs cannot cache these responses, so retrieving a variant will always require two HTTP requests (first to the AS controller, which then redirects to S3). The `derivation_endpoint` makes it easy to configure redirection to public non-expiring URLs.

```rb
plugin :derivation_endpoint,
  upload: true,                          # cache derivatives on storage
  upload_options: { acl: "public-read" } # make derivatives public readable
  upload_redirect: true,                 # redirect to derivatives on storage
  upload_redirect_url: { public: true }  # generate non-expiring URLs
```

Another improvement over Active Storage is that the endpoint doesn't make any DB queries when processing the request. The uploaded file data is encoded in the URL, so the endpoint already has all the information it needs to download the original file.

## Cache busting

Because `derivation_endpoint` doesn't encode processing steps in the URL, if the processing logic for a given derivation is changed, some URLs can still point to an older version of the derivative if your CDN has them cached. If the developer wants to "bust the cache", they'll need to bump the "version" of the URL. For example, the following example bumps the version for the `:thumbnail` derivation:

```rb
plugin :derivation_endpoint, version: -> { 1 if name == :thumbnail }
```

Now any new `:thumbnail` derivation URLs will have `version=1` appended to them.

```rb
photo.image.derivation_url(:thumbnail, "600", "400")
#=> "/derivations/image/thumbnail/600/400/eyJmZvbyIb3JhZ2UiOiJzdG9yZSJ9?version=1&signature=..."
```

I don't know if this strategy is problematic, but I feel like a need to bust the cache will be very rare.

## Authentication & Authorization

What happens if you want to **authenticate** derivative downloads in your Rails app? The `derivation_endpoint` lets you drop an abstraction lower, and call the endpoint from a controller:

```rb
# config/routes.rb
Rails.application.routes.draw do
  get "/derivations/image/*rest" => "derivations#image"
end
```
```rb
# app/controllers/derivations_controller.rb
class DerivativesController < ApplicationController
  before_filter :authenticate_user! # perform authentication before handling the derivation request

  def image
    set_rack_response ImageUploader.derivation_response(request.env)
  end

  private

  def set_rack_response((status, headers, body))
    self.status = status
    self.headers.merge!(headers)
    self.response_body = body
  end
end
```

And what if you also want to **authorize** derivative downloads? Well, you can drop another level lower, and generate the derivation response on an uploaded file:

```rb
# config/routes.rb
Rails.application.routes.draw do
  resources :photos do
    member do
      get "thumbnail" # for example
    end
  end
end
```
```rb
# app/controllers/photos_controller.rb
class PhotosController < ApplicationController
  def thubmnail
    photo = current_user.photos.find(params[:id]) # scope photos to the current user
    image = photo.image

    set_rack_response image.derivation_response(:thumbnail, 300, 300, env: request.env)
  end

  private

  def set_rack_response((status, headers, body))
    self.status = status
    self.headers.merge!(headers)
    self.response_body = body
  end
end
```

## Other features

The `derivation_endpoint` also has some other useful features:

* opt-in expiring URLs
* overriding `Content-Type` response header
* overriding `Content-Disposition` response header
* passing download options for source file (e.g. server-side encryption parameters for S3)

For detailed documentation, read the [plugin documentation](https://github.com/shrinerb/shrine/blob/62829fb119b5a26deb99e8a62e4146335325acd6/lib/shrine/plugins/derivation_endpoint.rb#L10-L550).