### PR TITLE
extract_metadata in StoreDimensions should have optional second arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## HEAD
+
+* Fix `store_dimensions` plugin making second argument in `Shrine#extract_metadata` mandatory (@jrochkind)
+
 ## 2.15.0 (2019-02-08)
 
 * Add `derivation_endpoint` plugin for processing uploaded files on-the-fly (@janko)

--- a/lib/shrine/plugins/store_dimensions.rb
+++ b/lib/shrine/plugins/store_dimensions.rb
@@ -38,7 +38,7 @@ class Shrine
 
       module InstanceMethods
         # We update the metadata with "width" and "height".
-        def extract_metadata(io, context)
+        def extract_metadata(io, context = {})
           width, height = extract_dimensions(io)
 
           super.merge!("width" => width, "height" => height)

--- a/test/plugin/store_dimensions_test.rb
+++ b/test/plugin/store_dimensions_test.rb
@@ -69,6 +69,13 @@ describe Shrine::Plugins::StoreDimensions do
     assert_equal 67,  uploaded_file.metadata["height"]
   end
 
+  it "overrides extract_metadata without changing method parameters" do
+    basic_uploader = uploader
+
+    assert_equal basic_uploader.method(:extract_metadata).parameters,
+      @uploader.method(:extract_metadata).parameters
+  end
+
   it "allows storing with custom extractor" do
     @shrine.plugin :store_dimensions, analyzer: ->(io){[5, 10]}
     assert_equal [5, 10], @shrine.extract_dimensions(fakeio)

--- a/test/plugin/store_dimensions_test.rb
+++ b/test/plugin/store_dimensions_test.rb
@@ -70,10 +70,10 @@ describe Shrine::Plugins::StoreDimensions do
   end
 
   it "overrides extract_metadata without changing method parameters" do
-    basic_uploader = uploader
+    extract_metadata          = @uploader.method(:extract_metadata)
+    original_extract_metadata = extract_metadata.super_method
 
-    assert_equal basic_uploader.method(:extract_metadata).parameters,
-      @uploader.method(:extract_metadata).parameters
+    assert_equal original_extract_metadata.parameters, extract_metadata.parameters
   end
 
   it "allows storing with custom extractor" do


### PR DESCRIPTION
The store_dimensions method being overridden has an optional second arg. https://github.com/shrinerb/shrine/blob/ee1ced8c99531cbd90df13e75c64953c1e07419a/lib/shrine.rb#L231

By overriding without a default param, the override made the method now have a required second param, basically changing it's signature with the override. Have a matching default arg to preserve semantics on override.

Note I didn't add a test yet, not sure if I should?