### PR TITLE
Allow S3 storage upload option to disable default content-disposition param

### DIFF
--- a/lib/shrine/storage/s3.rb
+++ b/lib/shrine/storage/s3.rb
@@ -110,7 +110,11 @@ class Shrine
         options.merge!(@upload_options)
         options.merge!(upload_options)
 
-        options[:content_disposition] = encode_content_disposition(options[:content_disposition]) if options[:content_disposition]
+        if options[:content_disposition]
+          options[:content_disposition] = encode_content_disposition(options[:content_disposition])
+        else # may be `false` meaning don't send it
+          options.delete(:content_disposition)
+        end
 
         if copyable?(io)
           copy(io, id, **options)

--- a/test/s3_test.rb
+++ b/test/s3_test.rb
@@ -130,6 +130,25 @@ describe Shrine::Storage::S3 do
         @s3.upload(tempfile("content"), "foo")
         assert_equal "prefix/foo", @s3.client.api_requests[0][:params][:key]
       end
+
+      it "accepts custom upload options" do
+        @s3.upload(tempfile("content"), "foo", content_type: "foo/bar")
+        assert_equal "foo/bar", @s3.client.api_requests[0][:params][:content_type]
+      end
+
+      it "accepts custom content-disposition upload option" do
+        @s3.upload(tempfile("content"), "foo",
+          shrine_metadata: { "filename" => "file.txt" },
+          content_disposition: 'attachment; filename="other.jpg"')
+        assert_equal 'attachment; filename="other.jpg"', @s3.client.api_requests[0][:params][:content_disposition]
+      end
+
+      it "accepts content_disposition false option to disable default" do
+        @s3.upload(tempfile("content"), "foo",
+          shrine_metadata: { "filename" => "file.txt" },
+          content_disposition: false)
+        refute @s3.client.api_requests[0][:params].has_key?(:content_disposition)
+      end
     end
 
     describe "on filesystem file" do


### PR DESCRIPTION
Also added test for ability to override default content-disposition. That was already possible, but I wasn't certain, and there wasn't a good test already.