### PR TITLE
Allow assign parsed json with symbol keys

### DIFF
--- a/lib/shrine/plugins/parsed_json.rb
+++ b/lib/shrine/plugins/parsed_json.rb
@@ -17,8 +17,9 @@ class Shrine
 
         private
 
-        def parsed_json?(hash)
-          hash.keys.any? { |key| key.is_a?(String) }
+        def parsed_json?(value)
+          (value.key?('id') || value.key?(:id)) &&
+          (value.key?('storage') || value.key?(:storage))
         end
       end
     end

--- a/test/plugin/parsed_json_test.rb
+++ b/test/plugin/parsed_json_test.rb
@@ -6,9 +6,19 @@ describe Shrine::Plugins::ParsedJson do
     @attacher = attacher { plugin :parsed_json }
   end
 
-  it "enables assigning cached files with hashes" do
+  it "enables assigning cached files with hashes with string keys" do
     cached_file = @attacher.cache!(fakeio)
     @attacher.assign(cached_file.data)
+    assert @attacher.get
+  end
+
+  it "enables assigning cached files with hashes with symbol keys" do
+    cached_file = @attacher.cache!(fakeio)
+    data = {
+      id:      cached_file.data["id"],
+      storage: cached_file.data["storage"]
+    }
+    @attacher.assign(data)
     assert @attacher.get
   end
 end


### PR DESCRIPTION
~Removed validation that hash should have at least one string key.
I think attacher already has enough validations, to check provided data~
Check presence of id and storage attributes as
Strings or as Symbols.

Hashes could also be provided by `rack_file` and `versions` plugins.
- Rack file plugin hash values have another keys (`tempfile`, `name`)
- Versions could have same keys, but its quite low possibility somebody has both
  `id` and `storage` versions names