### PR TITLE
Allow options to analyzers in determining_mime_type plugin

### DIFF
--- a/doc/plugins/determine_mime_type.md
+++ b/doc/plugins/determine_mime_type.md
@@ -39,7 +39,7 @@ Currently, Marcel is the only analyzer that accepts options to be passed in.
 Analyzer options can be set in one of two ways:
 
 ```rb
-plugin :determine_mime_type, analyzer: :marcel, options: { filename_fallback: true }
+plugin :determine_mime_type, analyzer: :marcel, analyzer_options: { filename_fallback: true }
 
 # or
 

--- a/lib/shrine/plugins/determine_mime_type.rb
+++ b/lib/shrine/plugins/determine_mime_type.rb
@@ -13,7 +13,7 @@ class Shrine
         end
 
         uploader.opts[:mime_type_analyzer] = opts.fetch(:analyzer, uploader.opts.fetch(:mime_type_analyzer, :file))
-        uploader.opts[:analyzer_options] = opts.fetch(:options, uploader.opts.fetch(:analyzer_options, {}))
+        uploader.opts[:mime_type_analyzer_options] = opts.fetch(:analyzer_options, uploader.opts.fetch(:mime_type_analyzer_options, {}))
       end
 
       module ClassMethods
@@ -26,7 +26,7 @@ class Shrine
           args     = if analyzer.is_a?(Proc)
               [io, mime_type_analyzers].take(analyzer.arity.abs)
             else
-              [io, opts[:analyzer_options]]
+              [io, opts[:mime_type_analyzer_options]]
             end
 
           mime_type = analyzer.call(*args)

--- a/lib/shrine/plugins/determine_mime_type.rb
+++ b/lib/shrine/plugins/determine_mime_type.rb
@@ -23,7 +23,11 @@ class Shrine
           analyzer = opts[:mime_type_analyzer]
 
           analyzer = mime_type_analyzer(analyzer) if analyzer.is_a?(Symbol)
-          args     = (analyzer.is_a?(Proc) ? [io, mime_type_analyzers] : [io, opts[:analyzer_options]])
+          args     = if analyzer.is_a?(Proc)
+              [io, mime_type_analyzers].take(analyzer.arity.abs)
+            else
+              [io, opts[:analyzer_options]]
+            end
 
           mime_type = analyzer.call(*args)
           io.rewind

--- a/lib/shrine/plugins/determine_mime_type.rb
+++ b/lib/shrine/plugins/determine_mime_type.rb
@@ -70,7 +70,7 @@ class Shrine
           @tool = tool
         end
 
-        def call(io, options: {})
+        def call(io, options = {})
           mime_type = send(:"extract_with_#{@tool}", io, options)
           io.rewind
 
@@ -165,7 +165,7 @@ class Shrine
           end
         end
 
-        def extract_filename(io, options)
+        def extract_filename(io)
           if io.respond_to?(:original_filename)
             io.original_filename
           elsif io.respond_to?(:path)

--- a/lib/shrine/plugins/determine_mime_type.rb
+++ b/lib/shrine/plugins/determine_mime_type.rb
@@ -135,7 +135,7 @@ class Shrine
 
           return nil if io.eof? # marcel returns "application/octet-stream" for empty files
 
-          Marcel::MimeType.for(io, name: extract_filename(io))
+          Marcel::MimeType.for(io)
         end
 
         def extract_with_mime_types(io)

--- a/test/plugin/determine_mime_type_test.rb
+++ b/test/plugin/determine_mime_type_test.rb
@@ -141,17 +141,17 @@ describe Shrine::Plugins::DetermineMimeType do
 
     describe "with options" do
       it "extracts MIME type of any IO" do
-        @shrine.plugin :determine_mime_type, analyzer: :marcel, options: { filename_fallback: false }
+        @shrine.plugin :determine_mime_type, analyzer: :marcel, analyzer_options: { filename_fallback: false }
         assert_equal "image/jpeg", @shrine.determine_mime_type(image)
       end
 
       it "returns application/octet-stream for unidentified MIME types" do
-        @shrine.plugin :determine_mime_type, analyzer: :marcel, options: { filename_fallback: false }
+        @shrine.plugin :determine_mime_type, analyzer: :marcel, analyzer_options: { filename_fallback: false }
         assert_equal "application/octet-stream", @shrine.determine_mime_type(fakeio("😃", filename: "smile.jpeg"))
       end
 
       it "returns application/octet-stream for unidentified MIME types" do
-        @shrine.plugin :determine_mime_type, analyzer: :marcel, options: { filename_fallback: true }
+        @shrine.plugin :determine_mime_type, analyzer: :marcel, analyzer_options: { filename_fallback: true }
         assert_equal "image/jpeg", @shrine.determine_mime_type(fakeio("😃", filename: "smile.jpeg"))
       end
     end

--- a/test/plugin/determine_mime_type_test.rb
+++ b/test/plugin/determine_mime_type_test.rb
@@ -129,10 +129,6 @@ describe Shrine::Plugins::DetermineMimeType do
       assert_equal "image/jpeg", @shrine.determine_mime_type(image)
     end
 
-    it "falls back to file extension" do
-      assert_equal "application/vnd.ms-excel", @shrine.determine_mime_type(fakeio("content", filename: "spreadsheet.xls"))
-    end
-
     it "returns application/octet-stream for unidentified MIME types" do
       assert_equal "application/octet-stream", @shrine.determine_mime_type(fakeio("😃"))
     end

--- a/test/plugin/determine_mime_type_test.rb
+++ b/test/plugin/determine_mime_type_test.rb
@@ -240,7 +240,7 @@ describe Shrine::Plugins::DetermineMimeType do
   end
 
   it "allows passing a custom extractor" do
-    @shrine.plugin :determine_mime_type, analyzer: ->(io, analyzers) { "foo/bar" }
+    @shrine.plugin :determine_mime_type, analyzer: ->(io) { "foo/bar" }
     assert_equal "foo/bar", @shrine.determine_mime_type(image)
 
     @shrine.plugin :determine_mime_type, analyzer: ->(io, analyzers) { analyzers[:file].call(io) }
@@ -248,7 +248,7 @@ describe Shrine::Plugins::DetermineMimeType do
   end
 
   it "always rewinds the file" do
-    @shrine.plugin :determine_mime_type, analyzer: ->(io, analyzers) { io.read }
+    @shrine.plugin :determine_mime_type, analyzer: ->(io) { io.read }
     @shrine.determine_mime_type(file = image)
     assert_equal 0, file.pos
   end


### PR DESCRIPTION
Reverts "Extended determine MIME type with Marcel" commit b1e5d836.

The change was introduced in v2.15.0. Since the filename can be anything, it was found in some small cases the mime-type determined based on filename can be incorrect. This also created a potential security issue for an application because filenames cannot be trusted. Therefore the change is reverted.

This commit allows passing in options to mime-type analyzers in `determine_mime_type` plugin. For now, Marcel is the only analyzer that makes use of any passed-in options but the implementation allows for other analyzers to have options if needed in future.

Marcel analyzer takes one option called `:filename_fallback` which can be set to true or false (default). When set to true, Marcel will also use the filename, if available, to determine the mime-type when it fails to find it using the file's magic number. This is designed to be opt-in for security reasons stated above.

Addresses issue #354.