### PR TITLE
Improve multi-chunk range requests

### DIFF
--- a/lib/shrine/plugins/rack_response.rb
+++ b/lib/shrine/plugins/rack_response.rb
@@ -128,9 +128,12 @@ class Shrine
           read_chunks do |chunk|
             chunk_range = bytes_read..(bytes_read + chunk.bytesize - 1)
 
-            if chunk_range.begin >= range.begin && chunk_range.end <= range.end
+            if chunk_range.begin > range.end
+              # no more chunks will match
+              return
+            elsif chunk_range.begin >= range.begin && chunk_range.end <= range.end
               yield chunk
-            elsif chunk_range.end >= range.begin || chunk_range.end <= range.end
+            elsif chunk_range.end >= range.begin && chunk_range.begin <= range.end
               requested_range_begin = [chunk_range.begin, range.begin].max - bytes_read
               requested_range_end   = [chunk_range.end, range.end].min - bytes_read
 


### PR DESCRIPTION
Range requests that began in a 2nd or later chunk were generating a requested range where the begin value was greater than the end value (eg: `22222..16383`). This caused `chunk.byteslice(...)` to return `nil` instead of a String, which in turn causes Puma (at least--others untested) to raise an exception.

This commit optimizes the begin/end condition to skip the chunk anytime the whole chunk is outside of range, which also avoids the possibility of yielding nil.

It also adds an optimization to end the entire iteration once the Down::ChunkedIO's position has gone past the requested range, which eliminates wasted effort downloading remote data that will be discarded anyway.