### PR TITLE
Fix derivation_endpoint breaking with moving plugin when :upload is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 * `rack_response` – prevent response body from yielding `nil`-chunks (@zarqman)
 
+* `derivation_endpoint` – Fix `:upload` option being incompatible with `moving` plugin (@speedo-spin)
+
 ## 2.16.0 (2019-02-18)
 
 * `derivation_endpoint` – Add `:upload_open_options` for download option for derivation result (@janko)

--- a/lib/shrine/plugins/derivation_endpoint.rb
+++ b/lib/shrine/plugins/derivation_endpoint.rb
@@ -631,7 +631,8 @@ class Shrine
         uploader.upload uploadable,
           location:       upload_location,
           upload_options: upload_options,
-          delete:         false # disable delete_raw plugin
+          delete:         false, # disable delete_raw plugin
+          move:           false # disable moving plugin
       end
     end
 

--- a/test/plugin/derivation_endpoint_test.rb
+++ b/test/plugin/derivation_endpoint_test.rb
@@ -999,6 +999,15 @@ describe Shrine::Plugins::DerivationEndpoint do
         @uploaded_file.derivation(:gray).upload(file)
         assert File.exist?(file.path)
       end
+
+      it "disables moving plugin" do
+        @shrine.plugin :moving
+        @uploader.storage.instance_eval { def movable?(*); true; end }
+        file = Tempfile.new
+        @uploaded_file.derivation(:gray).upload(file)
+        assert @uploaded_file.exists?
+        assert File.exist?(file.path)
+      end
     end
 
     describe "#retrieve" do


### PR DESCRIPTION
resolve issue https://github.com/shrinerb/shrine/issues/358