### PR TITLE
Add  ignore errors option in remote url plugin

### DIFF
--- a/doc/plugins/remote_url.md
+++ b/doc/plugins/remote_url.md
@@ -83,6 +83,12 @@ plugin :remote_url, error_message: "download failed"
 plugin :remote_url, error_message: -> (url, error) { I18n.t("errors.download_failed") }
 ```
 
+## Ignore errors
+If you encounter an error in Download, use this to disable the error.
+```rb
+plugin :remote_url, ignore_errors: true
+```
+
 ## Background
 
 If you want the file to be downloaded from the URL in the background, you can

--- a/lib/shrine/plugins/remote_url.rb
+++ b/lib/shrine/plugins/remote_url.rb
@@ -14,6 +14,7 @@ class Shrine
         uploader.opts[:remote_url_downloader] = opts.fetch(:downloader, uploader.opts.fetch(:remote_url_downloader, :open_uri))
         uploader.opts[:remote_url_max_size] = opts.fetch(:max_size, uploader.opts[:remote_url_max_size])
         uploader.opts[:remote_url_error_message] = opts.fetch(:error_message, uploader.opts[:remote_url_error_message])
+        uploader.opts[:remote_url_ignore_errors] = opts.fetch(:ignore_errors, uploader.opts[:remote_url_ignore_errors])
       end
 
       module AttachmentMethods
@@ -42,6 +43,7 @@ class Shrine
           begin
             downloaded_file = download(url, downloader)
           rescue => error
+            return if shrine_class.opts[:remote_url_ignore_errors]
             download_error = error
           end
 

--- a/lib/shrine/plugins/remote_url.rb
+++ b/lib/shrine/plugins/remote_url.rb
@@ -14,7 +14,7 @@ class Shrine
         uploader.opts[:remote_url_downloader] = opts.fetch(:downloader, uploader.opts.fetch(:remote_url_downloader, :open_uri))
         uploader.opts[:remote_url_max_size] = opts.fetch(:max_size, uploader.opts[:remote_url_max_size])
         uploader.opts[:remote_url_error_message] = opts.fetch(:error_message, uploader.opts[:remote_url_error_message])
-        uploader.opts[:remote_url_ignore_errors] = opts.fetch(:ignore_errors, uploader.opts[:remote_url_ignore_errors])
+        uploader.opts[:remote_url_ignore_errors] = opts.fetch(:ignore_errors, uploader.opts.fetch(:remote_url_ignore_errors, false))
       end
 
       module AttachmentMethods

--- a/test/plugin/remote_url_test.rb
+++ b/test/plugin/remote_url_test.rb
@@ -107,6 +107,13 @@ describe Shrine::Plugins::RemoteUrl do
     refute_includes @user.avatar_attacher.errors, "foo"
   end
 
+  it "accepts ignore errors" do
+    @attacher.shrine_class.opts[:remote_url_ignore_errors] = true
+    @user.avatar_remote_url = bad_url
+    assert_empty @user.avatar_attacher.errors
+    refute @user.avatar
+  end
+
   def good_url
     "http://example.com/good.jpg"
   end


### PR DESCRIPTION
I'm sorry for the sudden PR.
I am currently using Shrine for a project. when using remote url, I thought that ignore errors was necessary for background and batch processing.
I expect this to be merge.

My English may be terrible because I am Japanese.
