### PR TITLE
Improve check for empty directory in Storage::FileSystem

### DIFF
--- a/lib/shrine/storage/file_system.rb
+++ b/lib/shrine/storage/file_system.rb
@@ -142,7 +142,7 @@ class Shrine
       # Cleans all empty subdirectories up the hierarchy.
       def clean(path)
         path.dirname.ascend do |pathname|
-          if pathname.children.empty? && pathname != directory
+          if Dir.empty?(pathname) && pathname != directory
             pathname.rmdir
           else
             break


### PR DESCRIPTION
Fixes #365

Dir.empty? does not load all the child directories into memory. This improves the performance for directories with a lot of children.

I decided to go with implementation that requires Ruby 2.4. We have to drop support for Ruby 2.3 before merging this PR.