### PR TITLE
Versions: allow Attacher#url to accept version name indifferently

### DIFF
--- a/lib/shrine/plugins/versions.rb
+++ b/lib/shrine/plugins/versions.rb
@@ -105,13 +105,7 @@ class Shrine
 
           if attachment.is_a?(Hash)
             if version
-              if attachment.key?(version)
-                attachment[version].url(**options)
-              elsif fallback = shrine_class.version_fallbacks[version]
-                url(fallback, **options)
-              else
-                default_url(**options, version: version)
-              end
+              indifferent_version_url(version, **options)
             else
               raise Error, "must call Shrine::Attacher#url with the name of the version"
             end
@@ -145,6 +139,30 @@ class Shrine
           else
             super
           end
+        end
+
+        # Looks for versioned url indifferently,
+        # i.e. given version name could be both String or Symbol
+        def indifferent_version_url(version, **options)
+          attachment = get
+
+          trying_symbolized_version(version) do |v|
+            return attachment[v].url(**options) if attachment.key?(v)
+          end
+
+          trying_symbolized_version(version) do |v|
+            if (fallback = shrine_class.version_fallbacks[v])
+              return url(fallback, **options)
+            end
+          end
+
+          default_url(**options, version: version)
+        end
+
+        # Helper method for #indifferent_version_url
+        def trying_symbolized_version(version)
+          yield(version) ||
+            (!version.is_a?(Symbol) && yield(version.to_s.to_sym))
         end
       end
     end

--- a/lib/shrine/plugins/versions.rb
+++ b/lib/shrine/plugins/versions.rb
@@ -105,6 +105,7 @@ class Shrine
 
           if attachment.is_a?(Hash)
             if version
+              version = version.to_sym
               if attachment.key?(version)
                 attachment[version].url(**options)
               elsif fallback = shrine_class.version_fallbacks[version]

--- a/test/plugin/versions_test.rb
+++ b/test/plugin/versions_test.rb
@@ -110,10 +110,9 @@ describe Shrine::Plugins::Versions do
   end
 
   describe "Attacher#url" do
-    it "accepts a version name indifferently" do
+    it "accepts a version name" do
       @attacher.set(thumb: @uploader.upload(fakeio))
       assert_equal @attacher.get[:thumb].url, @attacher.url(:thumb)
-      assert_equal @attacher.get[:thumb].url, @attacher.url("thumb")
     end
 
     it "returns nil when a attachment doesn't exist" do

--- a/test/plugin/versions_test.rb
+++ b/test/plugin/versions_test.rb
@@ -110,9 +110,10 @@ describe Shrine::Plugins::Versions do
   end
 
   describe "Attacher#url" do
-    it "accepts a version name" do
+    it "accepts a version name indifferently" do
       @attacher.set(thumb: @uploader.upload(fakeio))
       assert_equal @attacher.get[:thumb].url, @attacher.url(:thumb)
+      assert_equal @attacher.get[:thumb].url, @attacher.url("thumb")
     end
 
     it "returns nil when a attachment doesn't exist" do


### PR DESCRIPTION
So both String & Symbol version names are working.

Perhaps this implementation could be "stricter" by simply symbolizing input version without "pre-symbolized" try.
I did it the way it is because I believe this approach is potentially less buggy, all it does is additionally tries symbolized version afterward in case the given one did not work out.