### PR TITLE
Prevent sharing of process blocks between parent and subclasses

### DIFF
--- a/lib/shrine/plugins/processing.rb
+++ b/lib/shrine/plugins/processing.rb
@@ -13,7 +13,7 @@ class Shrine
       module ClassMethods
         def process(action, &block)
           opts[:processing][action] ||= []
-          opts[:processing][action] << block
+          opts[:processing][action] += [block]
         end
       end
 


### PR DESCRIPTION
Cf #379 for the full issue. Long story short, blocks registered via `process` were not behaving as one would expect when defined accross a hierarchy of Uploaders.