### PR TITLE
Fix typo in S3 documentation

### DIFF
--- a/doc/storage/s3.md
+++ b/doc/storage/s3.md
@@ -256,7 +256,7 @@ To use Amazon S3's [Transfer Acceleration] feature, set
 `:use_accelerate_endpoint` to `true` when initializing the storage:
 
 ```rb
-Shrine::Storage::S3.new(use_accelerate_enpdoint: true, **other_options)
+Shrine::Storage::S3.new(use_accelerate_endpoint: true, **other_options)
 ```
 
 ## Clearing cache


### PR DESCRIPTION
Accidentally copy pasted this without noticing the mistake and ran into configuration issues.