### PR TITLE
Allow setting the identifier in pretty location plugin

### DIFF
--- a/doc/plugins/pretty_location.md
+++ b/doc/plugins/pretty_location.md
@@ -28,7 +28,7 @@ plugin :pretty_location, namespace: "/"
 # "blog/user/.../493g82jf23.jpg"
 ```
 
-By default if a record responds to `id`, this will is used in the location. 
+By default, if there is a record present, the record `id` will is used in the location.
 If you want to use a different identifier for the record, you can pass in
 the `:identifier` option with the desired method/attribute name as the value:
 
@@ -39,5 +39,15 @@ plugin :pretty_location, identifier: "uuid"
 plugin :pretty_location, identifier: :email
 # "user/foo@bar.com/profile_picture/493g82jf23.jpg"
 ```
+
+For a more custom identifier logic, you can overwrite the method `generate_location`
+and call `pretty_location` with the identifier you have calculated.
+
+```rb
+def generate_location(io, context)
+  identifier = context[:record].email if context[:record].is_a?(User)
+  pretty_location(io, context, identifier: identifier)
+end
+```rb
 
 [pretty_location]: /lib/shrine/plugins/pretty_location.rb

--- a/doc/plugins/pretty_location.md
+++ b/doc/plugins/pretty_location.md
@@ -28,4 +28,16 @@ plugin :pretty_location, namespace: "/"
 # "blog/user/.../493g82jf23.jpg"
 ```
 
+By default if a record responds to `id`, this will is used in the location. 
+If you want to use a different identifier for the record, you can pass in
+the `:identifier` option with the desired method/attribute name as the value:
+
+```rb
+plugin :pretty_location, identifier: "uuid"
+# "user/aa357797-5845-451b-8662-08eecdc9f762/profile_picture/493g82jf23.jpg"
+
+plugin :pretty_location, identifier: :email
+# "user/foo@bar.com/profile_picture/493g82jf23.jpg"
+```
+
 [pretty_location]: /lib/shrine/plugins/pretty_location.rb

--- a/lib/shrine.rb
+++ b/lib/shrine.rb
@@ -233,11 +233,7 @@ class Shrine
     # file extension. Can be overriden in uploaders for generating custom
     # location.
     def generate_location(io, context = {})
-      extension   = ".#{io.extension}" if io.is_a?(UploadedFile) && io.extension
-      extension ||= File.extname(extract_filename(io).to_s).downcase
-      basename    = generate_uid(io)
-
-      basename + extension
+      basic_location(io)
     end
 
     # Extracts filename, size and MIME type from the file, which is later
@@ -327,6 +323,15 @@ class Shrine
     # Delegates to #process.
     def processed(io, context)
       process(io, context)
+    end
+
+    # Generates a basic location for an uploaded file
+    def basic_location(io)
+      extension   = ".#{io.extension}" if io.is_a?(UploadedFile) && io.extension
+      extension ||= File.extname(extract_filename(io).to_s).downcase
+      basename    = generate_uid(io)
+
+      basename + extension
     end
 
     # Retrieves the location for the given IO and context. First it looks

--- a/lib/shrine/plugins/pretty_location.rb
+++ b/lib/shrine/plugins/pretty_location.rb
@@ -14,10 +14,10 @@ class Shrine
       module InstanceMethods
         def generate_location(io, context)
           identifier = record_identifier(context[:record], opts[:pretty_location_identifier])
-          pretty_location(io, identifier, context)
+          pretty_location(io, context, identifier: identifier)
         end
 
-        def pretty_location(io, identifier, context = {})
+        def pretty_location(io, context = {}, identifier:)
           if context[:record]
             type = class_location(context[:record].class) if context[:record].class.name
           end
@@ -35,11 +35,11 @@ class Shrine
         def record_identifier(record, method)
           return unless record
 
-          identifier = nil
-          identifier = record.send(method) if method && record.respond_to?(method)
-          identifier = record.id if !identifier && record.respond_to?(:id)
-
-          identifier
+          if method
+            record.send(method)
+          else
+            record.id
+          end
         end
 
         def class_location(klass)

--- a/lib/shrine/plugins/pretty_location.rb
+++ b/lib/shrine/plugins/pretty_location.rb
@@ -13,17 +13,7 @@ class Shrine
 
       module InstanceMethods
         def generate_location(io, context)
-          default_identifier = :id
-          param_identifier   = opts[:pretty_location_identifier]
-
-          if param_identifier && context[:record].respond_to?(param_identifier)
-            identifier = context[:record].public_send(param_identifier)
-          elsif context[:record].respond_to?(default_identifier)
-            identifier = context[:record].public_send(default_identifier)
-          else
-            identifier = nil
-          end
-
+          identifier = record_identifier(context[:record], opts[:pretty_location_identifier])
           pretty_location(io, identifier, context)
         end
 
@@ -41,6 +31,16 @@ class Shrine
         end
 
         private
+
+        def record_identifier(record, method)
+          return unless record
+
+          identifier = nil
+          identifier = record.send(method) if method && record.respond_to?(method)
+          identifier = record.id if !identifier && record.respond_to?(:id)
+
+          identifier
+        end
 
         def class_location(klass)
           parts = klass.name.downcase.split("::")

--- a/lib/shrine/plugins/pretty_location.rb
+++ b/lib/shrine/plugins/pretty_location.rb
@@ -13,14 +13,23 @@ class Shrine
 
       module InstanceMethods
         def generate_location(io, context)
-          identifier = (opts[:pretty_location_identifier] || :id).to_sym
+          default_identifier = :id
+          param_identifier   = opts[:pretty_location_identifier]
+
+          if param_identifier && context[:record].respond_to?(param_identifier)
+            identifier = context[:record].public_send(param_identifier)
+          elsif context[:record].respond_to?(default_identifier)
+            identifier = context[:record].public_send(default_identifier)
+          else
+            identifier = nil
+          end
+
           pretty_location(io, identifier, context)
         end
 
         def pretty_location(io, identifier, context = {})
           if context[:record]
             type = class_location(context[:record].class) if context[:record].class.name
-            id   = context[:record].public_send(identifier) if context[:record].respond_to?(identifier)
           end
           name = context[:name]
 
@@ -28,7 +37,7 @@ class Shrine
           basename = "#{context[:version]}-#{basename}" if context[:version]
           original = dirname + slash + basename
 
-          [type, id, name, original].compact.join("/")
+          [type, identifier, name, original].compact.join("/")
         end
 
         private

--- a/lib/shrine/plugins/pretty_location.rb
+++ b/lib/shrine/plugins/pretty_location.rb
@@ -8,13 +8,15 @@ class Shrine
     module PrettyLocation
       def self.configure(uploader, opts = {})
         uploader.opts[:pretty_location_namespace] = opts.fetch(:namespace, uploader.opts[:pretty_location_namespace])
+        uploader.opts[:pretty_location_identifier] = opts.fetch(:identifier, uploader.opts[:pretty_location_identifier])
       end
 
       module InstanceMethods
         def generate_location(io, context)
           if context[:record]
-            type = class_location(context[:record].class) if context[:record].class.name
-            id   = context[:record].id if context[:record].respond_to?(:id)
+            identifier = (opts[:pretty_location_identifier] || :id).to_sym
+            type       = class_location(context[:record].class) if context[:record].class.name
+            id         = context[:record].public_send(identifier) if context[:record].respond_to?(identifier)
           end
           name = context[:name]
 

--- a/lib/shrine/plugins/pretty_location.rb
+++ b/lib/shrine/plugins/pretty_location.rb
@@ -13,14 +13,18 @@ class Shrine
 
       module InstanceMethods
         def generate_location(io, context)
+          identifier = (opts[:pretty_location_identifier] || :id).to_sym
+          pretty_location(io, identifier, context)
+        end
+
+        def pretty_location(io, identifier, context = {})
           if context[:record]
-            identifier = (opts[:pretty_location_identifier] || :id).to_sym
-            type       = class_location(context[:record].class) if context[:record].class.name
-            id         = context[:record].public_send(identifier) if context[:record].respond_to?(identifier)
+            type = class_location(context[:record].class) if context[:record].class.name
+            id   = context[:record].public_send(identifier) if context[:record].respond_to?(identifier)
           end
           name = context[:name]
 
-          dirname, slash, basename = super.rpartition("/")
+          dirname, slash, basename = basic_location(io).rpartition("/")
           basename = "#{context[:version]}-#{basename}" if context[:version]
           original = dirname + slash + basename
 

--- a/test/plugin/pretty_location_test.rb
+++ b/test/plugin/pretty_location_test.rb
@@ -16,6 +16,18 @@ describe Shrine::Plugins::PrettyLocation do
     assert_match %r{^openstruct/123/avatar/[\w-]+$}, uploaded_file.id
   end
 
+  it "includes different identifier when :identifier is set and the record respond to it" do
+    @uploader.class.plugin :pretty_location, identifier: :uuid
+    uploaded_file = @uploader.upload(fakeio, record: OpenStruct.new(id: 123, uuid: 'xyz'), name: :avatar)
+    assert_match %r{^openstruct/xyz/avatar/[\w-]+$}, uploaded_file.id
+  end
+
+  it "does not include an identifier when :identifier is set but the record does not respond to it" do
+    @uploader.class.plugin :pretty_location, identifier: :uuid
+    uploaded_file = @uploader.upload(fakeio, record: OpenStruct.new(id: 123), name: :avatar)
+    assert_match %r{^openstruct/avatar/[\w-]+$}, uploaded_file.id
+  end
+
   it "prepends version names to generated location" do
     uploaded_file = @uploader.upload(fakeio(filename: "foo.jpg"), version: :thumb)
     assert_match %r{^thumb-[\w-]+\.jpg$}, uploaded_file.id

--- a/test/plugin/pretty_location_test.rb
+++ b/test/plugin/pretty_location_test.rb
@@ -22,9 +22,15 @@ describe Shrine::Plugins::PrettyLocation do
     assert_match %r{^openstruct/xyz/avatar/[\w-]+$}, uploaded_file.id
   end
 
-  it "does not include an identifier when :identifier is set but the record does not respond to it" do
+  it "includes the default identifier when :identifier is set but the record does not respond to it" do
     @uploader.class.plugin :pretty_location, identifier: :uuid
     uploaded_file = @uploader.upload(fakeio, record: OpenStruct.new(id: 123), name: :avatar)
+    assert_match %r{^openstruct/123/avatar/[\w-]+$}, uploaded_file.id
+  end
+
+  it "does not include an identifier when the record does not respond :identifier nor to the default identifier" do
+    @uploader.class.plugin :pretty_location, identifier: :uuid
+    uploaded_file = @uploader.upload(fakeio, record: OpenStruct.new(email: 'foo@bar'), name: :avatar)
     assert_match %r{^openstruct/avatar/[\w-]+$}, uploaded_file.id
   end
 

--- a/test/plugin/pretty_location_test.rb
+++ b/test/plugin/pretty_location_test.rb
@@ -3,6 +3,13 @@ require "shrine/plugins/pretty_location"
 require "ostruct"
 
 describe Shrine::Plugins::PrettyLocation do
+  class WhinyOpenStruct < OpenStruct
+    def method_missing(_, *_args)
+      raise NoMethodError
+      super
+    end
+  end
+
   module NameSpaced
     class OpenStruct < ::OpenStruct; end
   end
@@ -11,9 +18,13 @@ describe Shrine::Plugins::PrettyLocation do
     @uploader = uploader { plugin :pretty_location }
   end
 
-  it "uses context to build the directory" do
+  it "uses context to build the directory when the record responds to the default identifier" do
     uploaded_file = @uploader.upload(fakeio, record: OpenStruct.new(id: 123), name: :avatar)
     assert_match %r{^openstruct/123/avatar/[\w-]+$}, uploaded_file.id
+  end
+
+  it "raises an error when the record does not respond to the default identifier" do
+    assert_raises(NoMethodError) { @uploader.upload(fakeio, record: WhinyOpenStruct.new(email: 'foo@bar'), name: :avatar) }
   end
 
   it "includes different identifier when :identifier is set and the record respond to it" do
@@ -22,16 +33,9 @@ describe Shrine::Plugins::PrettyLocation do
     assert_match %r{^openstruct/xyz/avatar/[\w-]+$}, uploaded_file.id
   end
 
-  it "includes the default identifier when :identifier is set but the record does not respond to it" do
+  it "raises an error when :identifier is set but the record does not respond to it" do
     @uploader.class.plugin :pretty_location, identifier: :uuid
-    uploaded_file = @uploader.upload(fakeio, record: OpenStruct.new(id: 123), name: :avatar)
-    assert_match %r{^openstruct/123/avatar/[\w-]+$}, uploaded_file.id
-  end
-
-  it "does not include an identifier when the record does not respond :identifier nor to the default identifier" do
-    @uploader.class.plugin :pretty_location, identifier: :uuid
-    uploaded_file = @uploader.upload(fakeio, record: OpenStruct.new(email: 'foo@bar'), name: :avatar)
-    assert_match %r{^openstruct/avatar/[\w-]+$}, uploaded_file.id
+    assert_raises(NoMethodError) { @uploader.upload(fakeio, record: WhinyOpenStruct.new(id: 123), name: :avatar) }
   end
 
   it "prepends version names to generated location" do


### PR DESCRIPTION
This PR allows `pretty_location` plugin to use different identifiers when building the location.
[Here](https://groups.google.com/forum/#!topic/ruby-shrine/7Wm1B529I30) is the discussion where this was proposed.