### PR TITLE
Fix activerecord plugin's after_commit callbacks to work in Rails 3.

### DIFF
--- a/lib/shrine/plugins/activerecord.rb
+++ b/lib/shrine/plugins/activerecord.rb
@@ -35,9 +35,11 @@ class Shrine
               attacher.save if attacher.changed?
             end
 
-            model.after_commit if: :persisted? do
-              attacher = send("#{name}_attacher")
-              attacher.finalize if attacher.changed?
+            [:create, :update].each do |action|
+              model.after_commit on: action do
+                attacher = send("#{name}_attacher")
+                attacher.finalize if attacher.changed?
+              end
             end
 
             model.after_commit on: :destroy do

--- a/lib/shrine/plugins/activerecord.rb
+++ b/lib/shrine/plugins/activerecord.rb
@@ -35,12 +35,12 @@ class Shrine
               attacher.save if attacher.changed?
             end
 
-            model.after_commit on: [:create, :update] do
+            model.after_commit if: :persisted? do
               attacher = send("#{name}_attacher")
               attacher.finalize if attacher.changed?
             end
 
-            model.after_commit on: [:destroy] do
+            model.after_commit on: :destroy do
               send("#{name}_attacher").destroy
             end
           end


### PR DESCRIPTION
Because the transaction_include_action? method in Rails 3  isn't supporting yet arrays of actions - see the code: https://github.com/rails/rails/blob/3-2-stable/activerecord/lib/active_record/transactions.rb#L370