### PR TITLE
Add mirroring plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD
 
+* `mirroring` – Add new plugin for replicating uploads and deletes to other storages (@janko)
+
 * `model` – Change disabling model attachment behaviour from `type: :entity` to `model: false` (@janko)
 
 * `sequel` – Rename `:callbacks` option to `:hooks` (@janko)

--- a/doc/plugins/mirroring.md
+++ b/doc/plugins/mirroring.md
@@ -1,0 +1,87 @@
+# Mirroring
+
+The [`mirroring`][mirroring] plugin enables replicating uploads and deletes to
+other storages. This can be useful for setting up a backup storage, or when
+migrating files from one storage to another.
+
+```rb
+Shrine.plugin :mirroring, mirror: { store: :other_store }
+```
+
+With the above setup, any upload and delete to `:store` will be replicated to
+`:other_store`.
+
+```rb
+uploaded_file = Shrine.upload(io, :store) # uploads to :store and :other_store
+uploaded_file.delete                      # deletes from :store and :other_store
+```
+
+## Multiple storages
+
+You can mirror to multiple storages by specifying an array:
+
+```rb
+Shrine.plugin :mirroring, mirror: {
+  store: [:other_store_1, :other_store_2]
+}
+```
+
+## Backup storage
+
+If you want the mirror storage to act as a backup, you can disable mirroring
+deletes:
+
+```rb
+Shrine.plugin :mirroring, mirror: { ... }, delete: false
+```
+
+## Backgrounding
+
+You can have mirroring performed in a background job:
+
+```rb
+Shrine.mirror_upload do |uploaded_file|
+  MirrorUploadJob.perform_async(uploaded_file.shrine_class, uploaded_file.data)
+end
+
+Shrine.mirror_delete do |uploaded_file|
+  MirrorDeleteJob.perform_async(uploaded_file.shrine_class, uploaded_file.data)
+end
+```
+```rb
+class MirrorUploadJob
+  include Sidekiq::Worker
+  def perform(shrine_class, file_data)
+    uploaded_file = Object.const_get(shrine_class).uploaded_file(file_data)
+    uploaded_file.mirror_upload
+  end
+end
+```
+```rb
+class MirrorDeleteJob
+  include Sidekiq::Worker
+  def perform(shrine_class, file_data)
+    uploaded_file = Object.const_get(shrine_class).uploaded_file(file_data)
+    uploaded_file.mirror_delete
+  end
+end
+```
+
+## API
+
+You can mirror manually via `UploadedFile#mirror_upload` and
+`UploadedFile#mirror_delete`:
+
+```rb
+# disable automatic mirroring of uploads and deletes
+Shrine.plugin :mirroring, mirror: { ... }, upload: false, delete: false
+```
+```rb
+file = Shrine.upload(io, :store) # upload to :store
+file.mirror_upload               # upload to :other_store
+
+file.delete                      # delete from :store
+file.mirror_delete               # delete from :other_store
+```
+
+[mirroring]: /lib/shrine/plugins/mirroring.rb

--- a/lib/shrine/plugins/mirroring.rb
+++ b/lib/shrine/plugins/mirroring.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+class Shrine
+  module Plugins
+    module Mirroring
+      UPLOAD = -> (uploaded_file) { uploaded_file.mirror_upload }
+      DELETE = -> (uploaded_file) { uploaded_file.mirror_delete }
+
+      def self.configure(uploader, **opts)
+        uploader.opts[:mirroring] ||= { upload: UPLOAD, delete: DELETE }
+        uploader.opts[:mirroring].merge!(opts)
+
+        fail Error, ":mirror option is required for mirroring plugin" unless uploader.opts[:mirroring][:mirror]
+      end
+
+      module ClassMethods
+        def mirrors(storage_key = nil)
+          if storage_key
+            mirrors = opts[:mirroring][:mirror][storage_key]
+
+            fail Error, "no mirrors registered for storage #{storage_key.inspect}" unless mirrors
+
+            Array(mirrors)
+          else
+            opts[:mirroring][:mirror]
+          end
+        end
+
+        def mirror_upload(&block)
+          if block
+            opts[:mirroring][:upload] = block
+          else
+            opts[:mirroring][:upload]
+          end
+        end
+
+        def mirror_delete(&block)
+          if block
+            opts[:mirroring][:delete] = block
+          else
+            opts[:mirroring][:delete]
+          end
+        end
+      end
+
+      module InstanceMethods
+        def upload(io, **options)
+          uploaded_file = super
+
+          if self.class.mirrors[storage_key] && self.class.mirror_upload
+            self.class.mirror_upload.call(uploaded_file)
+          end
+
+          uploaded_file
+        end
+      end
+
+      module FileMethods
+        def mirror_upload
+          previously_opened = opened?
+
+          each_mirror do |mirror|
+            rewind if opened?
+
+            shrine_class.upload(self, mirror, location: id, close: false)
+          end
+        ensure
+          if opened? && !previously_opened
+            close
+            @io = nil
+          end
+        end
+
+        def delete
+          result = super
+
+          if shrine_class.mirrors[storage_key] && shrine_class.mirror_delete
+            shrine_class.mirror_delete.call(self)
+          end
+
+          result
+        end
+
+        def mirror_delete
+          each_mirror do |mirror|
+            self.class.new(id: id, storage: mirror).delete
+          end
+        end
+
+        private
+
+        def each_mirror(&block)
+          mirrors = shrine_class.mirrors(storage_key)
+          mirrors.map(&block)
+        end
+      end
+    end
+
+    register_plugin(:mirroring, Mirroring)
+  end
+end

--- a/test/plugin/mirroring_test.rb
+++ b/test/plugin/mirroring_test.rb
@@ -1,0 +1,197 @@
+require "test_helper"
+require "shrine/plugins/mirroring"
+
+describe Shrine::Plugins::Mirroring do
+  before do
+    @shrine   = shrine { plugin :mirroring, mirror: { store: :other_store } }
+    @uploader = @shrine.new(:store)
+  end
+
+  describe "Shrine" do
+    describe "#upload" do
+      it "mirrors uploads" do
+        file = @uploader.upload(fakeio)
+
+        assert_equal :store, file.storage_key
+
+        mirrored_file = @shrine.uploaded_file(id: file.id, storage: :other_store)
+
+        assert mirrored_file.exists?
+      end
+
+      it "uses custom mirroring block" do
+        block_called = false
+        @shrine.mirror_upload do |uploaded_file|
+          assert_instance_of @shrine::UploadedFile, uploaded_file
+          block_called = true
+        end
+
+        file = @uploader.upload(fakeio)
+
+        assert block_called
+
+        mirrored_file = @shrine.uploaded_file(id: file.id, storage: :other_store)
+
+        refute mirrored_file.exists?
+      end
+
+      it "allows disabling mirroring" do
+        @shrine.plugin :mirroring, upload: false
+
+        file = @uploader.upload(fakeio)
+
+        mirrored_file = @shrine.uploaded_file(id: file.id, storage: :other_store)
+
+        refute mirrored_file.exists?
+      end
+
+      it "handles no mirroring" do
+        @shrine.plugin :mirroring, mirror: {}
+
+        @uploader.upload(fakeio)
+      end
+    end
+  end
+
+  describe "UploadedFile" do
+    describe "#mirror_upload" do
+      before do
+        @shrine.plugin :mirroring, upload: false
+
+        @file          = @uploader.upload(fakeio("file"))
+        @mirrored_file = @shrine.uploaded_file(id: @file.id, storage: :other_store)
+      end
+
+      it "uploads to mirror storages" do
+        @file.mirror_upload
+
+        assert @mirrored_file.exists?
+        assert_equal "file", @mirrored_file.read
+      end
+
+      it "returns mirrored files" do
+        files = @file.mirror_upload
+
+        assert_equal [@mirrored_file], files
+      end
+
+      it "handles mirroring to multiple storages" do
+        @shrine.plugin :mirroring, mirror: { store: [:other_store, :other_store] }
+
+        @file.mirror_upload
+
+        assert @mirrored_file.exists?
+        assert_equal "file", @mirrored_file.read
+      end
+
+      it "opens the source file only once" do
+        @shrine.plugin :mirroring, mirror: { store: [:other_store, :other_store] }
+
+        @file.storage.expects(:open).once.returns(StringIO.new("file"))
+
+        @file.mirror_upload
+      end
+
+      it "doesn't open the source file if not required" do
+        @shrine.plugin :mirroring, mirror: { store: [:other_store, :other_store] }
+
+        @shrine.storages[:other_store].instance_eval do
+          def upload(io, id, **)
+            # doesn't read the source file
+          end
+        end
+
+        @file.storage.expects(:open).never
+
+        @file.mirror_upload
+      end
+
+      it "closes the source file" do
+        @file.mirror_upload
+
+        refute @file.opened?
+      end
+
+      it "doesn't close the source file if user opened it" do
+        @file.open do
+          @file.mirror_upload
+
+          assert @file.opened?
+          refute @file.to_io.closed?
+        end
+      end
+
+      it "raises exception when mirrors not registered" do
+        @shrine.plugin :mirroring, mirror: {}
+
+        assert_raises Shrine::Error do
+          @file.mirror_upload
+        end
+      end
+    end
+
+    describe "#delete" do
+      before do
+        @file          = @uploader.upload(fakeio)
+        @mirrored_file = @shrine.uploaded_file(id: @file.id, storage: :other_store)
+      end
+
+      it "mirrors deletes" do
+        @file.delete
+
+        refute @mirrored_file.exists?
+      end
+
+      it "uses custom mirroring block" do
+        block_called = false
+        @shrine.mirror_delete do |uploaded_file|
+          assert_instance_of @shrine::UploadedFile, uploaded_file
+          block_called = true
+        end
+
+        @file.delete
+
+        assert block_called
+
+        assert @mirrored_file.exists?
+      end
+
+      it "allows disabling mirroring" do
+        @shrine.plugin :mirroring, delete: false
+
+        @file.delete
+
+        assert @mirrored_file.exists?
+      end
+
+      it "handles no mirroring" do
+        @shrine.plugin :mirroring, mirror: {}
+
+        @file.delete
+      end
+    end
+
+    describe "#mirror_delete" do
+      before do
+        @shrine.plugin :mirroring, delete: false
+
+        @file          = @uploader.upload(fakeio("file"))
+        @mirrored_file = @shrine.uploaded_file(id: @file.id, storage: :other_store)
+      end
+
+      it "deletes from mirror storages" do
+        @file.mirror_delete
+
+        refute @mirrored_file.exists?
+      end
+
+      it "raises exception when mirrors not registered" do
+        @shrine.plugin :mirroring, mirror: {}
+
+        assert_raises Shrine::Error do
+          @file.mirror_delete
+        end
+      end
+    end
+  end
+end

--- a/www/_data/plugins.yml
+++ b/www/_data/plugins.yml
@@ -140,3 +140,6 @@ Other:
   -
     name: keep_files
     description: Prevents file deletion when replacing or removing attachment.
+  -
+    name: mirroring
+    description: Enables replicating uploads and deletes to other storages.


### PR DESCRIPTION
This adds a new `mirroring` plugin that was requested in https://github.com/shrinerb/shrine/issues/174. This achieves similar functionality as Active Storage's [Mirror Service](https://guides.rubyonrails.org/active_storage_overview.html#mirror-service).

Previously I was recommending [using the `instrumentation` plugin](https://github.com/shrinerb/shrine/wiki/Mirroring-Uploads), but I think the implementation is sufficiently complex (and sufficiently requested) that it makes sense to put it into a plugin.

Tests and docs are still missing, but I just wanted to get preliminary feedback in case anyone wanted to chime in.

### Usage

You set it up specifying which storage should be mirrored where:

```rb
Shrine.storages = {
  cache: Shrine::Storage::S3.new(...),
  store: Shrine::Storage::S3.new(...),
  gcs:   Shrine::Storage::GoogleCloudStorage.new(...),
}

Shrine.plugin :mirroring, mirror: { store: :gcs }
```

With the configuration above, all uploads and deletes to `:store` will be mirrored to `:gcs`.

### Backgrounding

You can move mirroring into a background job:

```rb
Shrine.mirror_upload do |uploaded_file|
  MirrorUpload.perform_async(uploaded_file.shrine_class, uploaded_file.data)
end

Shrine.mirror_delete do |uploaded_file|
  MirrorDelete.perform_async(uploaded_file.shrine_class, uploaded_file.data)
end
```
```rb
class MirrorUpload
  def perform(shrine_class, file_data)
    uploaded_file = Object.const_get(shrine_class).uploaded_file(file_data)
    uploaded_file.mirror_upload
  end
end
```
```rb
class MirrorDelete
  def perform(shrine_class, file_data)
    uploaded_file = Object.const_get(shrine_class).uploaded_file(file_data)
    uploaded_file.mirror_delete
  end
end
```

### Backup

If the user wants one storage to act as backup storage, they can disable deleting:

```rb
Shrine.plugin :mirroring, mirror: { ... }, delete: false
```

### API

The user can always disable automatic uploading and deleting, and use `UploadedFile#mirror_upload` and `UploadedFile#mirror_delete` themselves.

```rb
Shrine.plugin :mirroring, mirror: {  ... }, upload: false, delete: false
```
```rb
uploaded_file.mirror_upload # uploads the file to each mirror storage
uploaded_file.mirror_delete # deletes the file from each mirror storage
```