### PR TITLE
improve pretty location class name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD
 
+* Add `:class_underscore` option to `pretty_location` plugin for underscoring class name (@Uysim)
+
 * Update `down` dependency to `~> 5.0` (@janko)
 
 ## 3.0.0.beta3 (2019-09-25)

--- a/doc/plugins/pretty_location.md
+++ b/doc/plugins/pretty_location.md
@@ -40,17 +40,14 @@ plugin :pretty_location, identifier: :email
 # "user/foo@bar.com/profile_picture/493g82jf23.jpg"
 ```
 
-By default, class name will be transform by downcase. We can change this behavoir by pass in the method name or proc to transform that class name.
+By default, class name will be transform by downcase. We can change this behavoir to pass in option `class_underscore`. It transform class name to underscore.
 
 ```ruby
 plugin :pretty_location
 # "blogpost/aa357797-5845-451b-8662-08eecdc9f762/image/493g82jf23.jpg"
 
-plugin :pretty_location, class_transform: :underscore
+plugin :pretty_location, class_underscore: :true
 # "blog_post/aa357797-5845-451b-8662-08eecdc9f762/image/493g82jf23.jpg"
-
-plugin :pretty_location, class_transform: ->(class_name){ "prefix_" + class_name.underscore }
-# "prefix_blog_post/aa357797-5845-451b-8662-08eecdc9f762/image/493g82jf23.jpg"
 ```
 
 

--- a/doc/plugins/pretty_location.md
+++ b/doc/plugins/pretty_location.md
@@ -40,7 +40,8 @@ plugin :pretty_location, identifier: :email
 # "user/foo@bar.com/profile_picture/493g82jf23.jpg"
 ```
 
-By default, class name will be transform by downcase. We can change this behavoir to pass in option `class_underscore`. It transform class name to underscore.
+By default, the class name will be only downcased. We can also have the class
+name underscored with the `:class_underscore` option:
 
 ```ruby
 plugin :pretty_location
@@ -49,8 +50,6 @@ plugin :pretty_location
 plugin :pretty_location, class_underscore: :true
 # "blog_post/aa357797-5845-451b-8662-08eecdc9f762/image/493g82jf23.jpg"
 ```
-
-
 
 For a more custom identifier logic, you can overwrite the method
 `#generate_location` and call `#pretty_location` with the identifier you have

--- a/doc/plugins/pretty_location.md
+++ b/doc/plugins/pretty_location.md
@@ -40,6 +40,21 @@ plugin :pretty_location, identifier: :email
 # "user/foo@bar.com/profile_picture/493g82jf23.jpg"
 ```
 
+By default, class name will be transform by downcase. We can change this behavoir by pass in the method name or proc to transform that class name.
+
+```ruby
+plugin :pretty_location
+# "blogpost/aa357797-5845-451b-8662-08eecdc9f762/image/493g82jf23.jpg"
+
+plugin :pretty_location, class_transform: :underscore
+# "blog_post/aa357797-5845-451b-8662-08eecdc9f762/image/493g82jf23.jpg"
+
+plugin :pretty_location, class_transform: ->(class_name){ "prefix_" + class_name.underscore }
+# "prefix_blog_post/aa357797-5845-451b-8662-08eecdc9f762/image/493g82jf23.jpg"
+```
+
+
+
 For a more custom identifier logic, you can overwrite the method
 `#generate_location` and call `#pretty_location` with the identifier you have
 calculated.

--- a/lib/shrine/plugins/pretty_location.rb
+++ b/lib/shrine/plugins/pretty_location.rb
@@ -7,7 +7,7 @@ class Shrine
     # [doc/plugins/pretty_location.md]: https://github.com/shrinerb/shrine/blob/master/doc/plugins/pretty_location.md
     module PrettyLocation
       def self.configure(uploader, **opts)
-        uploader.opts[:pretty_location] ||= { identifier: :id }
+        uploader.opts[:pretty_location] ||= { identifier: :id, class_transform: :downcase }
         uploader.opts[:pretty_location].merge!(opts)
       end
 
@@ -34,9 +34,19 @@ class Shrine
           record.public_send(opts[:pretty_location][:identifier])
         end
 
+        def transform_class_name(class_name)
+          class_transform = opts[:pretty_location][:class_transform]
+
+          if class_transform.respond_to?(:call)
+            class_transform.call(class_name)
+          else
+            class_name.send(class_transform)
+          end
+        end
+
         def record_namespace(record)
           class_name = record.class.name or return
-          parts      = class_name.downcase.split("::")
+          parts      = transform_class_name(class_name).split("::")
 
           if separator = opts[:pretty_location][:namespace]
             parts.join(separator)

--- a/lib/shrine/plugins/pretty_location.rb
+++ b/lib/shrine/plugins/pretty_location.rb
@@ -7,7 +7,7 @@ class Shrine
     # [doc/plugins/pretty_location.md]: https://github.com/shrinerb/shrine/blob/master/doc/plugins/pretty_location.md
     module PrettyLocation
       def self.configure(uploader, **opts)
-        uploader.opts[:pretty_location] ||= { identifier: :id, class_transform: :downcase }
+        uploader.opts[:pretty_location] ||= { identifier: :id }
         uploader.opts[:pretty_location].merge!(opts)
       end
 
@@ -35,12 +35,10 @@ class Shrine
         end
 
         def transform_class_name(class_name)
-          class_transform = opts[:pretty_location][:class_transform]
-
-          if class_transform.respond_to?(:call)
-            class_transform.call(class_name)
+          if opts[:pretty_location][:class_underscore]
+            class_name.gsub(/([A-Z]+)([A-Z][a-z])/, '\1_\2').gsub(/([a-z])([A-Z])/, '\1_\2').downcase
           else
-            class_name.send(class_transform)
+            class_name.downcase
           end
         end
 

--- a/test/plugin/pretty_location_test.rb
+++ b/test/plugin/pretty_location_test.rb
@@ -90,6 +90,31 @@ describe Shrine::Plugins::PrettyLocation do
         assert_match %r{^namespaced_entity/123/file/\w+$}, location
       end
 
+      it "transform class name with underscore when :class_transform is set to underscore" do
+        @shrine.plugin :pretty_location, class_transform: :underscore
+
+        location = @uploader.generate_location(
+          fakeio,
+          record: NameSpaced::Entity.new(123),
+          name: :file,
+        )
+
+        assert_match %r{^name_spaced/entity/123/file/\w+$}, location
+      end
+
+      it "transform class name with given proc when :class_transform is a proc" do
+        @shrine.plugin :pretty_location, class_transform: ->(class_name){ "prefix_" + class_name.underscore }
+
+        location = @uploader.generate_location(
+          fakeio,
+          record: NameSpaced::Entity.new(123),
+          name: :file,
+        )
+
+        assert_match %r{^prefix_name_spaced/entity/123/file/\w+$}, location
+      end
+
+
       it "fails when record does not respond to default identifier" do
         assert_raises NoMethodError do
           @uploader.generate_location(

--- a/test/plugin/pretty_location_test.rb
+++ b/test/plugin/pretty_location_test.rb
@@ -90,8 +90,8 @@ describe Shrine::Plugins::PrettyLocation do
         assert_match %r{^namespaced_entity/123/file/\w+$}, location
       end
 
-      it "transform class name with underscore when :class_transform is set to underscore" do
-        @shrine.plugin :pretty_location, class_transform: :underscore
+      it "transform class name with underscore when :class_underscore is set to true" do
+        @shrine.plugin :pretty_location, class_underscore: :true, namespace: "/"
 
         location = @uploader.generate_location(
           fakeio,
@@ -101,19 +101,6 @@ describe Shrine::Plugins::PrettyLocation do
 
         assert_match %r{^name_spaced/entity/123/file/\w+$}, location
       end
-
-      it "transform class name with given proc when :class_transform is a proc" do
-        @shrine.plugin :pretty_location, class_transform: ->(class_name){ "prefix_" + class_name.underscore }
-
-        location = @uploader.generate_location(
-          fakeio,
-          record: NameSpaced::Entity.new(123),
-          name: :file,
-        )
-
-        assert_match %r{^prefix_name_spaced/entity/123/file/\w+$}, location
-      end
-
 
       it "fails when record does not respond to default identifier" do
         assert_raises NoMethodError do


### PR DESCRIPTION
This pull request base on discussion in google group of [pretty print is not pretty](https://groups.google.com/forum/#!searchin/ruby-shrine/pretty%7Csort:date/ruby-shrine/M8KmbVQz6mk/mqz4J9BPAgAJ). 

It is improve the way we transform the class name