### PR TITLE
#delete_prefixed

### DIFF
--- a/doc/creating_storages.md
+++ b/doc/creating_storages.md
@@ -206,7 +206,7 @@ The storage can support additional options to customize how the presign will be
 generated, those can be forwarded via the `:presign_options` option on the
 `presign_endpoint` plugin.
 
-## Clear and delete_prefixed
+## Delete Prefixed and Clear
 
 There are two methods that are not currently used by shrine, but which it's good
 for storages to provide to allow client code to delete files from storage. If
@@ -220,12 +220,12 @@ service functionality, storages should usually implement if possible.
 ```rb
 class MyStorage
   # ...
-  def clear!
-    # deletes all files in the storage
-  end
-
   def delete_prefixed(prefix_path)
     # deletes all files under the supplied argument prefix
+  end
+
+  def clear!
+    # deletes all files in the storage
   end
   # ...
 end

--- a/doc/creating_storages.md
+++ b/doc/creating_storages.md
@@ -206,17 +206,26 @@ The storage can support additional options to customize how the presign will be
 generated, those can be forwarded via the `:presign_options` option on the
 `presign_endpoint` plugin.
 
-## Clear
+## Clear and delete_prefixed
 
-While this method is not used by Shrine, it is good to give users the
-possibility to delete all files in a storage, and the conventional name for
-this method is `#clear!`.
+There are two methods that are not currently used by shrine, but which it's good
+for storages to provide to allow client code to delete files from storage. If
+storages provide these conventional methods, then clients can delete files using
+consistent API for any storage.
+
+`#clear!` deletes all files from storage, and `#delete_prefixed` will delete all
+files in a given directory/prefix/path. While not strictly required for shrine storage
+service functionality, storages should usually implement if possible.
 
 ```rb
 class MyStorage
   # ...
   def clear!
     # deletes all files in the storage
+  end
+
+  def delete_prefixed(prefix_path)
+    # deletes all files under the supplied argument prefix
   end
   # ...
 end

--- a/doc/storage/file_system.md
+++ b/doc/storage/file_system.md
@@ -74,6 +74,15 @@ You can retrieve path to the file using `#path`:
 storage.path("image.jpg") #=> #<Pathname:public/image.jpg>
 ```
 
+## Deleting prefixed
+
+If you want to delete all files in some directory, you can use
+`FileSystem#delete_prefixed`:
+
+```rb
+storage.delete_prefixed("some_directory") # deletes all files in "some_directory/"
+```
+
 ## Clearing cache
 
 If you're using FileSystem as cache, you will probably want to periodically

--- a/doc/storage/s3.md
+++ b/doc/storage/s3.md
@@ -259,6 +259,15 @@ To use Amazon S3's [Transfer Acceleration] feature, set
 Shrine::Storage::S3.new(use_accelerate_endpoint: true, **other_options)
 ```
 
+## Deleting prefixed
+
+If you want to delete all objects in some prefix, you can use
+`S3#delete_prefixed`:
+
+```rb
+s3.delete_prefixed("some_prefix") # deletes all objects in "some_prefix/"
+```
+
 ## Clearing cache
 
 If you're using S3 as a cache, you will probably want to periodically delete

--- a/lib/shrine/storage/file_system.rb
+++ b/lib/shrine/storage/file_system.rb
@@ -109,8 +109,8 @@ class Shrine
       # Delete files at keys starting with the prefix.
       #
       #    file_system.delete_prefixed("somekey/derivatives/")
-      def delete_prefixed(prefix)
-        FileUtils.rm_rf(directory.join(prefix))
+      def delete_prefixed(delete_prefix)
+        FileUtils.rm_rf(directory.join(delete_prefix).to_s)
       end
 
       # Returns the full path to the file.

--- a/lib/shrine/storage/file_system.rb
+++ b/lib/shrine/storage/file_system.rb
@@ -89,9 +89,9 @@ class Shrine
       rescue Errno::ENOENT
       end
 
-      # Delete files at keys starting with the prefix.
+      # Deletes the specified directory on the filesystem.
       #
-      #    file_system.delete_prefixed("somekey/derivatives/")
+      #    file_system.delete_prefixed("somekey/derivatives")
       def delete_prefixed(delete_prefix)
         FileUtils.rm_rf directory.join(delete_prefix)
       end

--- a/lib/shrine/storage/file_system.rb
+++ b/lib/shrine/storage/file_system.rb
@@ -70,6 +70,16 @@ class Shrine
         path(id).exist?
       end
 
+      # If #prefix is not present, returns a path composed of #directory and
+      # the given `id`. If #prefix is present, it excludes the #directory part
+      # from the returned path (e.g. #directory can be set to "public" folder).
+      # Both cases accept a `:host` value which will be prefixed to the
+      # generated path.
+      def url(id, host: nil, **options)
+        path = (prefix ? relative_path(id) : path(id)).to_s
+        host ? host + path : path
+      end
+
       # Delets the file, and by default deletes the containing directory if
       # it's empty.
       def delete(id)
@@ -79,14 +89,11 @@ class Shrine
       rescue Errno::ENOENT
       end
 
-      # If #prefix is not present, returns a path composed of #directory and
-      # the given `id`. If #prefix is present, it excludes the #directory part
-      # from the returned path (e.g. #directory can be set to "public" folder).
-      # Both cases accept a `:host` value which will be prefixed to the
-      # generated path.
-      def url(id, host: nil, **options)
-        path = (prefix ? relative_path(id) : path(id)).to_s
-        host ? host + path : path
+      # Delete files at keys starting with the prefix.
+      #
+      #    file_system.delete_prefixed("somekey/derivatives/")
+      def delete_prefixed(delete_prefix)
+        FileUtils.rm_rf directory.join(delete_prefix)
       end
 
       # Deletes all files from the #directory. If a block is passed in, deletes
@@ -104,13 +111,6 @@ class Shrine
         else
           directory.children.each(&:rmtree)
         end
-      end
-
-      # Delete files at keys starting with the prefix.
-      #
-      #    file_system.delete_prefixed("somekey/derivatives/")
-      def delete_prefixed(delete_prefix)
-        FileUtils.rm_rf(directory.join(delete_prefix).to_s)
       end
 
       # Returns the full path to the file.

--- a/lib/shrine/storage/file_system.rb
+++ b/lib/shrine/storage/file_system.rb
@@ -106,6 +106,13 @@ class Shrine
         end
       end
 
+      # Delete files at keys starting with the prefix.
+      #
+      #    file_system.delete_prefixed("somekey/derivatives/")
+      def delete_prefixed(prefix)
+        FileUtils.rm_rf(directory.join(prefix))
+      end
+
       # Returns the full path to the file.
       def path(id)
         directory.join(id.gsub("/", File::SEPARATOR))

--- a/lib/shrine/storage/linter.rb
+++ b/lib/shrine/storage/linter.rb
@@ -46,7 +46,7 @@ class Shrine
           storage.upload(io_factory.call, id2 = "a/a/b")
           storage.upload(io_factory.call, id3 = "a/aaa/a")
 
-          lint_delete_prefixed(prefix: "a/a/",
+          lint_delete_prefixed(prefix: "a/a",
                                expect_deleted: [id1, id2],
                                expect_remaining: [id3])
 

--- a/lib/shrine/storage/memory.rb
+++ b/lib/shrine/storage/memory.rb
@@ -35,9 +35,7 @@ class Shrine
       end
 
       def delete_prefixed(delete_prefix)
-        # normalize to trailing slash
-        delete_prefix = delete_prefix.chomp('/') + '/'
-        store.delete_if { |k, _v| k.start_with?(delete_prefix) }
+        store.delete_if { |k, _v| k.start_with?(delete_prefix + "/") }
       end
 
       def clear!

--- a/lib/shrine/storage/memory.rb
+++ b/lib/shrine/storage/memory.rb
@@ -22,26 +22,26 @@ class Shrine
         raise Shrine::FileNotFound, "file #{id.inspect} not found on storage"
       end
 
-      def url(id, *)
-        "memory://#{id}"
-      end
-
       def exists?(id)
         store.key?(id)
+      end
+
+      def url(id, *)
+        "memory://#{id}"
       end
 
       def delete(id)
         store.delete(id)
       end
 
-      def clear!
-        store.clear
-      end
-
       def delete_prefixed(delete_prefix)
         # normalize to trailing slash
         delete_prefix = delete_prefix.chomp('/') + '/'
         store.delete_if { |k, _v| k.start_with?(delete_prefix) }
+      end
+
+      def clear!
+        store.clear
       end
     end
   end

--- a/lib/shrine/storage/memory.rb
+++ b/lib/shrine/storage/memory.rb
@@ -22,6 +22,10 @@ class Shrine
         raise Shrine::FileNotFound, "file #{id.inspect} not found on storage"
       end
 
+      def url(id, *)
+        "memory://#{id}"
+      end
+
       def exists?(id)
         store.key?(id)
       end
@@ -30,12 +34,14 @@ class Shrine
         store.delete(id)
       end
 
-      def url(id, *)
-        "memory://#{id}"
-      end
-
       def clear!
         store.clear
+      end
+
+      def delete_prefixed(delete_prefix)
+        # normalize to trailing slash
+        delete_prefix = delete_prefix.chomp('/') + '/'
+        store.delete_if { |k, _v| k.start_with?(delete_prefix) }
       end
     end
   end

--- a/lib/shrine/storage/s3.rb
+++ b/lib/shrine/storage/s3.rb
@@ -205,6 +205,16 @@ class Shrine
         object(id).delete
       end
 
+      # Delete files at keys starting with the prefix.
+      #
+      #    s3.delete_prefixed("somekey/derivatives/")
+      def delete_prefixed(delete_prefix)
+        # We need to make sure to combine with storage prefix, and
+        # that it ends in '/' cause S3 can be squirrely about matching interior.
+        normalized_prefix = [*prefix, delete_prefix.chomp("/"), ""].join("/")
+        bucket.objects(prefix: normalized_prefix).batch_delete!
+      end
+
       # If block is given, deletes all objects from the storage for which the
       # block evaluates to true. Otherwise deletes all objects from the storage.
       #
@@ -216,16 +226,6 @@ class Shrine
         objects_to_delete = objects_to_delete.lazy.select(&block) if block
 
         delete_objects(objects_to_delete)
-      end
-
-      # Delete files at keys starting with the prefix.
-      #
-      #    s3.delete_prefixed("somekey/derivatives/")
-      def delete_prefixed(delete_prefix)
-        # We need to make sure to combine with storage prefix, and
-        # that it ends in '/' cause S3 can be squirrely about matching interior.
-        normalized_prefix = [*prefix, delete_prefix.chomp("/"), ""].join("/")
-        bucket.objects(prefix: normalized_prefix).batch_delete!
       end
 
       # Returns an `Aws::S3::Object` for the given id.

--- a/lib/shrine/storage/s3.rb
+++ b/lib/shrine/storage/s3.rb
@@ -218,6 +218,16 @@ class Shrine
         delete_objects(objects_to_delete)
       end
 
+      # Delete files at keys starting with the prefix.
+      #
+      #    s3.delete_prefixed("somekey/derivatives/")
+      def delete_prefixed(delete_prefix)
+        # We need to make sure to combine with storage prefix, and
+        # that it ends in '/' cause S3 can be squirrely about matching interior.
+        normalized_prefix = [*prefix, delete_prefix.chomp("/"), ""].join("/")
+        bucket.objects(prefix: normalized_prefix).batch_delete!
+      end
+
       # Returns an `Aws::S3::Object` for the given id.
       def object(id)
         bucket.object([*prefix, id].join("/"))

--- a/lib/shrine/storage/s3.rb
+++ b/lib/shrine/storage/s3.rb
@@ -205,14 +205,14 @@ class Shrine
         object(id).delete
       end
 
-      # Delete files at keys starting with the prefix.
+      # Deletes objects at keys starting with the specified prefix.
       #
-      #    s3.delete_prefixed("somekey/derivatives/")
+      #    s3.delete_prefixed("somekey/derivatives")
       def delete_prefixed(delete_prefix)
         # We need to make sure to combine with storage prefix, and
         # that it ends in '/' cause S3 can be squirrely about matching interior.
-        normalized_prefix = [*prefix, delete_prefix.chomp("/"), ""].join("/")
-        bucket.objects(prefix: normalized_prefix).batch_delete!
+        absolute_prefix = [*prefix, delete_prefix + "/"].join("/")
+        bucket.objects(prefix: absolute_prefix).batch_delete!
       end
 
       # If block is given, deletes all objects from the storage for which the

--- a/test/storage/file_system_test.rb
+++ b/test/storage/file_system_test.rb
@@ -182,6 +182,32 @@ describe Shrine::Storage::FileSystem do
     end
   end
 
+  describe "#url" do
+    it "returns the full path without :prefix" do
+      @storage = file_system(root)
+      @storage.upload(fakeio, "foo.jpg")
+      assert_equal "#{root}/foo.jpg", @storage.url("foo.jpg")
+    end
+
+    it "applies a host without :prefix" do
+      @storage = file_system(root)
+      @storage.upload(fakeio, "foo.jpg")
+      assert_equal "http://124.83.12.24#{root}/foo.jpg", @storage.url("foo.jpg", host: "http://124.83.12.24")
+    end
+
+    it "returns the path relative to the :prefix" do
+      @storage = file_system(root, prefix: "uploads")
+      @storage.upload(fakeio, "foo.jpg")
+      assert_equal "/uploads/foo.jpg", @storage.url("foo.jpg")
+    end
+
+    it "accepts a host with :prefix" do
+      @storage = file_system(root, prefix: "uploads")
+      @storage.upload(fakeio, "foo.jpg")
+      assert_equal "http://abc123.cloudfront.net/uploads/foo.jpg", @storage.url("foo.jpg", host: "http://abc123.cloudfront.net")
+    end
+  end
+
   describe "#delete" do
     it "cleans subdirectories" do
       @storage.upload(fakeio, "a/a/a.jpg")
@@ -214,32 +240,6 @@ describe Shrine::Storage::FileSystem do
       @storage.delete_prefixed("a/a/")
       refute @storage.exists?("a/a/a.jpg")
       refute @storage.exists?("a/a")
-    end
-  end
-
-  describe "#url" do
-    it "returns the full path without :prefix" do
-      @storage = file_system(root)
-      @storage.upload(fakeio, "foo.jpg")
-      assert_equal "#{root}/foo.jpg", @storage.url("foo.jpg")
-    end
-
-    it "applies a host without :prefix" do
-      @storage = file_system(root)
-      @storage.upload(fakeio, "foo.jpg")
-      assert_equal "http://124.83.12.24#{root}/foo.jpg", @storage.url("foo.jpg", host: "http://124.83.12.24")
-    end
-
-    it "returns the path relative to the :prefix" do
-      @storage = file_system(root, prefix: "uploads")
-      @storage.upload(fakeio, "foo.jpg")
-      assert_equal "/uploads/foo.jpg", @storage.url("foo.jpg")
-    end
-
-    it "accepts a host with :prefix" do
-      @storage = file_system(root, prefix: "uploads")
-      @storage.upload(fakeio, "foo.jpg")
-      assert_equal "http://abc123.cloudfront.net/uploads/foo.jpg", @storage.url("foo.jpg", host: "http://abc123.cloudfront.net")
     end
   end
 

--- a/test/storage/file_system_test.rb
+++ b/test/storage/file_system_test.rb
@@ -223,7 +223,7 @@ describe Shrine::Storage::FileSystem do
       @storage.upload(fakeio, "a/b/b.jpg")
       @storage.upload(fakeio, "a/aaaa/b.jpg")
 
-      @storage.delete_prefixed("a/a/")
+      @storage.delete_prefixed("a/a")
 
       refute @storage.exists?("a/a/a.jpg")
       refute @storage.exists?("a/a/b.jpg")
@@ -237,7 +237,7 @@ describe Shrine::Storage::FileSystem do
       @storage = file_system(root, prefix: "uploads")
 
       @storage.upload(fakeio, "a/a/a.jpg")
-      @storage.delete_prefixed("a/a/")
+      @storage.delete_prefixed("a/a")
       refute @storage.exists?("a/a/a.jpg")
       refute @storage.exists?("a/a")
     end

--- a/test/storage/file_system_test.rb
+++ b/test/storage/file_system_test.rb
@@ -190,6 +190,33 @@ describe Shrine::Storage::FileSystem do
     end
   end
 
+  describe "#delete_prefixed" do
+    it "deletes contents and empty dir" do
+      @storage.upload(fakeio, "a/a/a.jpg")
+      @storage.upload(fakeio, "a/a/b.jpg")
+      @storage.upload(fakeio, "a/b/b.jpg")
+      @storage.upload(fakeio, "a/aaaa/b.jpg")
+
+      @storage.delete_prefixed("a/a/")
+
+      refute @storage.exists?("a/a/a.jpg")
+      refute @storage.exists?("a/a/b.jpg")
+      refute @storage.exists?("a/a")
+
+      assert @storage.exists?("a/b/b.jpg")
+      assert @storage.exists?("a/aaaa/b.jpg")
+    end
+
+    it "respects storage prefix" do
+      @storage = file_system(root, prefix: "uploads")
+
+      @storage.upload(fakeio, "a/a/a.jpg")
+      @storage.delete_prefixed("a/a/")
+      refute @storage.exists?("a/a/a.jpg")
+      refute @storage.exists?("a/a")
+    end
+  end
+
   describe "#url" do
     it "returns the full path without :prefix" do
       @storage = file_system(root)

--- a/test/storage/linter_test.rb
+++ b/test/storage/linter_test.rb
@@ -86,6 +86,20 @@ describe Shrine::Storage::Linter do
     end
   end
 
+  describe "delete_prefixed" do
+    it "tests that files get cleared" do
+      @storage.instance_eval { def delete_prefixed(p); end }
+      assert_raises(Shrine::LintError) { @linter.call }
+    end
+
+    it "doesn't require #clear! to be defined" do
+      if @storage.respond_to?(:delete_prefixed)
+        @storage.instance_eval { undef delete_prefixed }
+      end
+      @linter.call
+    end
+  end
+
   describe "#presign" do
     before do
       @storage.instance_eval { def presign(id, **options); { method: "post", url: "foo" }; end }

--- a/test/storage/linter_test.rb
+++ b/test/storage/linter_test.rb
@@ -18,7 +18,7 @@ describe Shrine::Storage::Linter do
     end
 
     it "takes into account that storage can modify location" do
-      @storage.instance_eval { def upload(io, id, *); id.replace("bar"); super; end }
+      @storage.instance_eval { def upload(io, id, *); id << "-modified"; super; end }
       @linter.call
     end
   end

--- a/test/storage/s3_test.rb
+++ b/test/storage/s3_test.rb
@@ -433,36 +433,6 @@ describe Shrine::Storage::S3 do
     end
   end
 
-  describe "#clear!" do
-    it "deletes all objects in the bucket" do
-      @s3.client.stub_responses(:list_objects, contents: [{ key: "foo" }])
-      @s3.clear!
-      assert_equal :list_objects,    @s3.client.api_requests[0][:operation_name]
-      assert_equal "my-bucket",      @s3.client.api_requests[0][:params][:bucket]
-      assert_equal :delete_objects,  @s3.client.api_requests[1][:operation_name]
-      assert_equal [{ key: "foo" }], @s3.client.api_requests[1][:params][:delete][:objects]
-    end
-
-    it "deletes subset of objects in the bucket" do
-      @s3.client.stub_responses(:list_objects, contents: [{ key: "foo" }, { key: "bar" }])
-      @s3.clear! { |object| object.key == "bar" }
-      assert_equal :list_objects,    @s3.client.api_requests[0][:operation_name]
-      assert_equal "my-bucket",      @s3.client.api_requests[0][:params][:bucket]
-      assert_equal :delete_objects,  @s3.client.api_requests[1][:operation_name]
-      assert_equal [{ key: "bar" }], @s3.client.api_requests[1][:params][:delete][:objects]
-    end
-
-    it "respects :prefix" do
-      @s3 = s3(prefix: "prefix")
-      @s3.client.stub_responses(:list_objects, contents: [{ key: "prefix/foo" }])
-      @s3.clear!
-      assert_equal :list_objects,           @s3.client.api_requests[0][:operation_name]
-      assert_equal "prefix",                @s3.client.api_requests[0][:params][:prefix]
-      assert_equal :delete_objects,         @s3.client.api_requests[1][:operation_name]
-      assert_equal [{ key: "prefix/foo" }], @s3.client.api_requests[1][:params][:delete][:objects]
-    end
-  end
-
   describe "#delete_prefixed" do
     it "deletes objects with specified prefix" do
       @s3.client.stub_responses(:list_objects, contents: [{ key: "delete_prefix/foo" }])
@@ -490,6 +460,36 @@ describe Shrine::Storage::S3 do
       assert_equal "prefix/delete_prefix/",               @s3.client.api_requests[0][:params][:prefix]
       assert_equal :delete_objects,                       @s3.client.api_requests[1][:operation_name]
       assert_equal [{ key: "prefix/delete_prefix/foo" }], @s3.client.api_requests[1][:params][:delete][:objects]
+    end
+  end
+
+  describe "#clear!" do
+    it "deletes all objects in the bucket" do
+      @s3.client.stub_responses(:list_objects, contents: [{ key: "foo" }])
+      @s3.clear!
+      assert_equal :list_objects,    @s3.client.api_requests[0][:operation_name]
+      assert_equal "my-bucket",      @s3.client.api_requests[0][:params][:bucket]
+      assert_equal :delete_objects,  @s3.client.api_requests[1][:operation_name]
+      assert_equal [{ key: "foo" }], @s3.client.api_requests[1][:params][:delete][:objects]
+    end
+
+    it "deletes subset of objects in the bucket" do
+      @s3.client.stub_responses(:list_objects, contents: [{ key: "foo" }, { key: "bar" }])
+      @s3.clear! { |object| object.key == "bar" }
+      assert_equal :list_objects,    @s3.client.api_requests[0][:operation_name]
+      assert_equal "my-bucket",      @s3.client.api_requests[0][:params][:bucket]
+      assert_equal :delete_objects,  @s3.client.api_requests[1][:operation_name]
+      assert_equal [{ key: "bar" }], @s3.client.api_requests[1][:params][:delete][:objects]
+    end
+
+    it "respects :prefix" do
+      @s3 = s3(prefix: "prefix")
+      @s3.client.stub_responses(:list_objects, contents: [{ key: "prefix/foo" }])
+      @s3.clear!
+      assert_equal :list_objects,           @s3.client.api_requests[0][:operation_name]
+      assert_equal "prefix",                @s3.client.api_requests[0][:params][:prefix]
+      assert_equal :delete_objects,         @s3.client.api_requests[1][:operation_name]
+      assert_equal [{ key: "prefix/foo" }], @s3.client.api_requests[1][:params][:delete][:objects]
     end
   end
 

--- a/test/storage/s3_test.rb
+++ b/test/storage/s3_test.rb
@@ -463,6 +463,26 @@ describe Shrine::Storage::S3 do
     end
   end
 
+  describe "#delete_prefixed" do
+    it "deletes objects with specified prefix" do
+      @s3.client.stub_responses(:list_objects, contents: [{ key: "delete_prefix/foo" }])
+      @s3.delete_prefixed("delete_prefix")
+      assert_equal :list_objects,                  @s3.client.api_requests[0][:operation_name]
+      assert_equal "delete_prefix/",               @s3.client.api_requests[0][:params][:prefix]
+      assert_equal :delete_objects,                @s3.client.api_requests[1][:operation_name]
+      assert_equal [{ key: "delete_prefix/foo" }], @s3.client.api_requests[1][:params][:delete][:objects]
+    end
+
+    it "deletes objects with specified prefix with trailing slash" do
+      @s3.client.stub_responses(:list_objects, contents: [{ key: "delete_prefix/foo" }])
+      @s3.delete_prefixed("delete_prefix/")
+      assert_equal :list_objects,                  @s3.client.api_requests[0][:operation_name]
+      assert_equal "delete_prefix/",               @s3.client.api_requests[0][:params][:prefix]
+      assert_equal :delete_objects,                @s3.client.api_requests[1][:operation_name]
+      assert_equal [{ key: "delete_prefix/foo" }], @s3.client.api_requests[1][:params][:delete][:objects]
+    end
+  end
+
   describe "#object" do
     it "returns an Aws::S3::Object" do
       object = @s3.object("foo")

--- a/test/storage/s3_test.rb
+++ b/test/storage/s3_test.rb
@@ -443,15 +443,6 @@ describe Shrine::Storage::S3 do
       assert_equal [{ key: "delete_prefix/foo" }], @s3.client.api_requests[1][:params][:delete][:objects]
     end
 
-    it "deletes objects with specified prefix with trailing slash" do
-      @s3.client.stub_responses(:list_objects, contents: [{ key: "delete_prefix/foo" }])
-      @s3.delete_prefixed("delete_prefix/")
-      assert_equal :list_objects,                  @s3.client.api_requests[0][:operation_name]
-      assert_equal "delete_prefix/",               @s3.client.api_requests[0][:params][:prefix]
-      assert_equal :delete_objects,                @s3.client.api_requests[1][:operation_name]
-      assert_equal [{ key: "delete_prefix/foo" }], @s3.client.api_requests[1][:params][:delete][:objects]
-    end
-
     it "respects storage prefix" do
       @s3 = s3(prefix: "prefix")
       @s3.client.stub_responses(:list_objects, contents: [{ key: "prefix/delete_prefix/foo" }])

--- a/test/storage/s3_test.rb
+++ b/test/storage/s3_test.rb
@@ -481,6 +481,16 @@ describe Shrine::Storage::S3 do
       assert_equal :delete_objects,                @s3.client.api_requests[1][:operation_name]
       assert_equal [{ key: "delete_prefix/foo" }], @s3.client.api_requests[1][:params][:delete][:objects]
     end
+
+    it "respects storage prefix" do
+      @s3 = s3(prefix: "prefix")
+      @s3.client.stub_responses(:list_objects, contents: [{ key: "prefix/delete_prefix/foo" }])
+      @s3.delete_prefixed("delete_prefix")
+      assert_equal :list_objects,                         @s3.client.api_requests[0][:operation_name]
+      assert_equal "prefix/delete_prefix/",               @s3.client.api_requests[0][:params][:prefix]
+      assert_equal :delete_objects,                       @s3.client.api_requests[1][:operation_name]
+      assert_equal [{ key: "prefix/delete_prefix/foo" }], @s3.client.api_requests[1][:params][:delete][:objects]
+    end
   end
 
   describe "#object" do


### PR DESCRIPTION
Closes #409

This adds #delete_prefixed to Shrine:Storage::S3 and Shrine::Storage::FileSystem

Also adds docs to creating_storages.md to explain and recommend #delete_prefixed

* Does not add to Memory, although it could add an inefficient imp without too much trouble. 

## Warning: No test for S3

I could not manage to get a stub_request-style setup to work to test S3, although it oughta be possible. I spent some time with the S3 stub_request docs and experimenting, just couldn't manage to get anywhere yet. Advice or help welcome. 

I DID test it locally -- I wrote a test on a _real_ S3 bucket with my own credentials, and made sure it passed (at first it didn't, finding a bug!). So I am confident in the code at present. But that's not reliable for preventing future regressions of course. 

## Linter

I DID add testing for delete_prefixed to the linter. Following example of existing 'optional' features tested by linter, it only tests it if respond_to?(:delete_prefixed). 

So FileSystem is actually double-tested, once by it's own tests, and once by linter. (linter was pre-existing not being run on S3).

I think it would be nice to add an option to the linter where it _insists_ on certain optional features, like `clear!` and `delete_prefixed`. As a develper using shrine, it can be nice to know whether I can rely on the full suite of utilities with a given storage, that would answer that question, and give third-party developers a target for 'maximal' implementation. But just mentioning in passing, that'd be for discussion or implementation elsewhere, not here.