### PR TITLE
Linter#call returns true, so you can make an assertion out of it in a test.

### DIFF
--- a/lib/shrine/storage/linter.rb
+++ b/lib/shrine/storage/linter.rb
@@ -51,6 +51,8 @@ class Shrine
         if storage.respond_to?(:presign)
           lint_presign(id)
         end
+
+        true
       end
 
       def lint_open(id)

--- a/test/storage/file_system_test.rb
+++ b/test/storage/file_system_test.rb
@@ -36,8 +36,8 @@ describe Shrine::Storage::FileSystem do
   end
 
   it "passes the linter" do
-    Shrine::Storage::Linter.new(file_system(root)).call
-    Shrine::Storage::Linter.new(file_system(root, prefix: "uploads")).call
+    assert Shrine::Storage::Linter.new(file_system(root)).call
+    assert Shrine::Storage::Linter.new(file_system(root, prefix: "uploads")).call
   end
 
   describe "#initialize" do

--- a/test/storage/linter_test.rb
+++ b/test/storage/linter_test.rb
@@ -8,7 +8,7 @@ describe Shrine::Storage::Linter do
   end
 
   it "passes for memory storage" do
-    @linter.call
+    assert @linter.call
   end
 
   describe "upload" do

--- a/test/storage/memory_test.rb
+++ b/test/storage/memory_test.rb
@@ -8,6 +8,6 @@ describe Shrine::Storage::Memory do
   end
 
   it "passes the linter" do
-    Shrine::Storage::Linter.call(@memory)
+    assert Shrine::Storage::Linter.call(@memory)
   end
 end


### PR DESCRIPTION
Previously, a test might look like this:

    it "passes the linter" do
      Shrine::Storage::Linter.call(@memory)
    end

If it fails it will raise an exception and fail the test, if it passes nothing happens. So it works. 

But when running MiniTest on that when it succeeds, it reports "0 assertions, 0 errors, 0 failures..."  Which is just kind of weird and not quite right. 

If we make Linter#call reliably return `true` if it finishes, then we can instead write:

    it "passes the linter" do
      assert Shrine::Storage::Linter.call(@memory)
    end

Pretty much exact same thing happens, except MiniTest on success says "1 assertion, 0 errors, 0 failures..." which is somewhat more accurate and more reassuring to see and know that the linter really was run,