### PR TITLE
Amend FileSystem documentation wrt moving

### DIFF
--- a/doc/storage/file_system.md
+++ b/doc/storage/file_system.md
@@ -64,7 +64,12 @@ File.exist?(file.path) #=> false
 ```
 
 If you want to make this option default, you can use the
-[`upload_options`][upload_options] plugin.
+[`upload_options`][upload_options] plugin, provided that both `:cache` and
+`:store` storages are `FileSystem`):
+
+```rb
+plugin :upload_options, cache: { move: true }, store: { move: true }
+```
 
 ## Path
 


### PR DESCRIPTION
Taken from https://github.com/shrinerb/shrine/commit/cea01426d01fb375e74392f78ec3e664514f3966

It took me a couple of minutes to figure this out, since the [release notes for 2.19](https://github.com/shrinerb/shrine/blob/eda05bc3189bc68e7f403bc11250100e4f0d6e34/doc/release_notes/2.19.0.md) just state that the `moving` plugin has been deprecated.

Maybe I should also add this to the release notes? WDYT?