### PR TITLE
Add a little styling to CodeFund ad

### DIFF
--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -62,3 +62,10 @@ code[class*="language-"] {
 code {
   font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
 }
+
+.cf-wrapper {
+  /* light red-tinted grey with grey border */
+  border: 1px solid rgb(172, 171, 171);
+  background-color: rgb(247, 246, 246);
+  border-radius: 3px;
+}


### PR DESCRIPTION
Add some styling to help separate the ad from the Shrine content without 
being too distracting.

This is what it will look like.
<img width="1116" alt="Screen Shot 2019-11-28 at 3 08 09 PM" src="https://user-images.githubusercontent.com/1156987/69835117-f4341300-11f3-11ea-88c3-ec3879684e67.png">


