### PR TITLE
Work around apparent StringIO bug in ruby 2.7.0

### DIFF
--- a/lib/shrine/storage/memory.rb
+++ b/lib/shrine/storage/memory.rb
@@ -17,7 +17,10 @@ class Shrine
       end
 
       def open(id, *)
-        StringIO.new(store.fetch(id))
+        str = store.fetch(id)
+        # work around apparent bug in ruby 2.7.0
+        # https://bugs.ruby-lang.org/issues/16497
+        StringIO.new(str).set_encoding(str.encoding)
       rescue KeyError
         raise Shrine::FileNotFound, "file #{id.inspect} not found on storage"
       end

--- a/lib/shrine/storage/memory.rb
+++ b/lib/shrine/storage/memory.rb
@@ -17,10 +17,9 @@ class Shrine
       end
 
       def open(id, *)
-        str = store.fetch(id)
-        # work around apparent bug in ruby 2.7.0
-        # https://bugs.ruby-lang.org/issues/16497
-        StringIO.new(str).set_encoding(str.encoding)
+        io = StringIO.new(store.fetch(id))
+        io.set_encoding(io.string.encoding) # Ruby 2.7.0 – https://bugs.ruby-lang.org/issues/16497
+        io
       rescue KeyError
         raise Shrine::FileNotFound, "file #{id.inspect} not found on storage"
       end

--- a/test/storage/memory_test.rb
+++ b/test/storage/memory_test.rb
@@ -10,4 +10,20 @@ describe Shrine::Storage::Memory do
   it "passes the linter" do
     assert Shrine::Storage::Linter.call(@memory)
   end
+
+
+  # work around apparent bug in ruby 2.7.0
+  # https://bugs.ruby-lang.org/issues/16497
+  it "preserves encoding despite Encoding.default_internal set" do
+    begin
+      original = Encoding.default_internal
+      Encoding.default_internal = Encoding::UTF_8
+
+      binary_string = "\x99".force_encoding("ASCII-8BIT")
+      @memory.upload(StringIO.new(binary_string, "r:ASCII-8BIT"), "key")
+      assert_equal @memory.open("key").read.encoding, Encoding::BINARY
+    ensure
+      Encoding.default_internal = original
+    end
+  end
 end

--- a/test/storage/memory_test.rb
+++ b/test/storage/memory_test.rb
@@ -11,19 +11,18 @@ describe Shrine::Storage::Memory do
     assert Shrine::Storage::Linter.call(@memory)
   end
 
-
   # work around apparent bug in ruby 2.7.0
   # https://bugs.ruby-lang.org/issues/16497
   it "preserves encoding despite Encoding.default_internal set" do
+    @memory.upload(fakeio("content".b), "key")
+
     begin
-      original = Encoding.default_internal
+      original_internal = Encoding.default_internal
       Encoding.default_internal = Encoding::UTF_8
 
-      binary_string = "\x99".force_encoding("ASCII-8BIT")
-      @memory.upload(StringIO.new(binary_string, "r:ASCII-8BIT"), "key")
-      assert_equal @memory.open("key").read.encoding, Encoding::BINARY
+      assert_equal Encoding::BINARY, @memory.open("key").read.encoding
     ensure
-      Encoding.default_internal = original
+      Encoding.default_internal = original_internal
     end
   end
 end


### PR DESCRIPTION
Confirmed the test added here does fail in ruby 2.7.0 without the code change, and passes with the code change.

Also confirmed this code change is what was needed for my actual app, which uses Storage::Memory in tests, to pass it's own tests in ruby 2.7. (Although my actual app is using shrine 2.x still, and made equivalent change in shrine 2.x Storage::Memory).

This appears to be a ruby bug in 2.7.0.

https://bugs.ruby-lang.org/issues/16497

https://www.reddit.com/r/ruby/comments/emd6q4/is_this_a_stringio_bug_in_ruby_270/

Yes, in this test we still need to supply an encoding to the StringIO in the test, also because of the ruby 2.7.0 bug. However, even doing that, the test fails without the code change here, and passes with it. And my actual app needed no other changes than the change here to pass again.