### PR TITLE
fix IO validation on upload_endpoint

### DIFF
--- a/lib/shrine/plugins/upload_endpoint.rb
+++ b/lib/shrine/plugins/upload_endpoint.rb
@@ -135,9 +135,14 @@ class Shrine
       end
 
       error!(400, "Upload Not Found") if value.nil?
-      error!(400, "Upload Not Valid") unless value.is_a?(Hash) && value[:tempfile]
-
-      @shrine_class.rack_file(value)
+      
+	    if value.is_a?(Hash) && value[:tempfile]
+		    return @shrine_class.rack_file(value)
+	    elsif value.respond_to?(:read) && value.respond_to?(:rewind)  && value.respond_to?(:eof?) && value.respond_to?(:close)
+	    	return value
+	    else
+	   	  error!(400, "Upload Not Valid")
+      end
     end
 
     # Returns a hash of information containing `:action` and `:request`

--- a/lib/shrine/plugins/upload_endpoint.rb
+++ b/lib/shrine/plugins/upload_endpoint.rb
@@ -135,13 +135,13 @@ class Shrine
       end
 
       error!(400, "Upload Not Found") if value.nil?
-      
-	    if value.is_a?(Hash) && value[:tempfile]
-		    return @shrine_class.rack_file(value)
-	    elsif value.respond_to?(:read) && value.respond_to?(:rewind)  && value.respond_to?(:eof?) && value.respond_to?(:close)
-	    	return value
-	    else
-	   	  error!(400, "Upload Not Valid")
+
+      if value.is_a?(Hash) && value[:tempfile]
+        @shrine_class.rack_file(value)
+      elsif %i[read rewind eof? close].all? { |m| value.respond_to?(m) }
+        value
+      else
+        error!(400, "Upload Not Valid")
       end
     end
 

--- a/test/plugin/upload_endpoint_test.rb
+++ b/test/plugin/upload_endpoint_test.rb
@@ -51,6 +51,15 @@ describe Shrine::Plugins::UploadEndpoint do
     assert_equal "Too Many Files", response.body_binary
   end
 
+  it "accepts already wrapped uploaded file (Rails)" do
+    Rack::Request.any_instance.stubs(:params).returns({ "file" => fakeio("file") })
+
+    response = app.post "/", multipart: { file: image }
+
+    assert_equal 200,    response.status
+    assert_equal "file", @shrine.uploaded_file(response.body_json).read
+  end
+
   it "validates maximum size" do
     @shrine.plugin :upload_endpoint, max_size: 10
     response = app.post "/", multipart: { file: image }


### PR DESCRIPTION
Fix IO validation on upload_endpoint as discussed here
https://discourse.shrinerb.com/t/upload-endpoint-with-authorization/121

Helps for example when someone wants to call Shrine.upload_response directly from a rails controller to add authentication.