### PR TITLE
Fix a doc typo

### DIFF
--- a/doc/advantages.md
+++ b/doc/advantages.md
@@ -93,7 +93,7 @@ low-level abstractions that give you the flexibility to build your own flow.
 ```rb
 uploaded_file = ImageUploader.upload(image, :store) # metadata extraction, upload location generation
 uploaded_file.id       #=> "44ccafc10ce6a4ff22829e8f579ee6b9.jpg"
-uplaoded_file.metadata #=> { ... extracted metadata ... }
+uploaded_file.metadata #=> { ... extracted metadata ... }
 
 data = uploaded_file.to_json # serialization
 # ...


### PR DESCRIPTION
Hi,

This PR fixes a typo in the `advantages.md`, `uplaoded_file` -> `uploaded_file`.