### PR TITLE
Fix typo

### DIFF
--- a/doc/plugins/dynamic_storage.md
+++ b/doc/plugins/dynamic_storage.md
@@ -12,7 +12,7 @@ Example:
 plugin :dynamic_storage
 
 storage /store_(\w+)/ do |match|
-  Shrine::Storages::S3.new(bucket: match[1])
+  Shrine::Storage::S3.new(bucket: match[1])
 end
 ```
 


### PR DESCRIPTION
Please confirm that the above is indeed a typo: I could not find a module called Storages (plural): Shrine::Storages so I made a big assumption that it should be Storage (singular)