### PR TITLE
Add auto_extraction option to store_dimensions plugin

### DIFF
--- a/doc/plugins/store_dimensions.md
+++ b/doc/plugins/store_dimensions.md
@@ -72,6 +72,8 @@ Shrine.dimensions(io) #=> [300, 400] (calls the defined analyzer)
 Shrine.dimensions_analyzers[:fastimage].call(io) #=> [300, 400] (calls a built-in analyzer)
 ```
 
+If you want to have access to those methods but not automatically add the metadata, you can setup this plugin with the `auto_extraction: false` option.
+
 ## Errors
 
 By default, any exceptions that the analyzer raises while extracting dimensions

--- a/lib/shrine/plugins/store_dimensions.rb
+++ b/lib/shrine/plugins/store_dimensions.rb
@@ -12,7 +12,7 @@ class Shrine
       end
 
       def self.configure(uploader, log_subscriber: LOG_SUBSCRIBER, **opts)
-        uploader.opts[:store_dimensions] ||= { analyzer: :fastimage, on_error: :warn }
+        uploader.opts[:store_dimensions] ||= { analyzer: :fastimage, on_error: :warn, auto_extraction: true }
         uploader.opts[:store_dimensions].merge!(opts)
 
         # resolve error strategy
@@ -71,11 +71,15 @@ class Shrine
       end
 
       module InstanceMethods
-        # We update the metadata with "width" and "height".
         def extract_metadata(io, **options)
-          width, height = self.class.extract_dimensions(io)
+          if self.class.opts[:store_dimensions][:auto_extraction]
+            # We update the metadata with "width" and "height".
+            width, height = self.class.extract_dimensions(io)
 
-          super.merge!("width" => width, "height" => height)
+            super.merge!("width" => width, "height" => height)
+          else
+            super
+          end
         end
       end
 

--- a/test/plugin/store_dimensions_test.rb
+++ b/test/plugin/store_dimensions_test.rb
@@ -210,4 +210,17 @@ describe Shrine::Plugins::StoreDimensions do
       @shrine.extract_dimensions(image)
     end
   end
+
+  describe "auto_extraction: false" do
+    it "does not add metadata" do
+      @shrine.plugin :store_dimensions, auto_extraction: false
+      uploaded_file = @uploader.upload(image)
+      assert_nil uploaded_file.metadata["width"]
+      assert_nil uploaded_file.metadata["height"]
+    end
+
+    it "provides method to extract dimensions from files" do
+      assert_equal [100, 67], @shrine.extract_dimensions(image)
+    end
+  end
 end


### PR DESCRIPTION
As discussed here https://discourse.shrinerb.com/t/store-dimensions-with-videos/177

I tried to not define `extract_metadata` if the option is not set, but I have not been able to find out if I can access the options from the module.