### PR TITLE
Add `skip_nil` option to `add_metadata` plugin

### DIFF
--- a/doc/plugins/add_metadata.md
+++ b/doc/plugins/add_metadata.md
@@ -34,6 +34,24 @@ uploaded_file.metadata["page_count"] #=> 30
 uploaded_file.page_count #=> 30
 ```
 
+By default, if your block returns `nil` then the `nil` value will be stored into
+metadata. If you do not want to store anything when your block returns nil, you
+can use the `skip_nil: true` option:
+
+```rb
+class PdfUploader < Shrine
+  add_metadata :pages, skip_nil: true do |io|
+    if is_pdf?(io)
+      reader = PDF::Reader.new(io)
+      reader.page_count
+    else
+      # If this is not a PDF, then the pages metadata will not be stored
+      nil
+    end
+  end
+end
+```
+
 ### Multiple values
 
 You can also extract multiple metadata values at once, by using `add_metadata`

--- a/test/plugin/add_metadata_test.rb
+++ b/test/plugin/add_metadata_test.rb
@@ -50,6 +50,20 @@ describe Shrine::Plugins::AddMetadata do
       end
     end
 
+    describe "with skip_nil option" do
+      it "does not ignore not nil values" do
+        @shrine.add_metadata(:custom, skip_nil: true) { false }
+        metadata = @uploader.extract_metadata(fakeio)
+        assert_equal false, metadata.fetch("custom")
+      end
+
+      it "ignores nil" do
+        @shrine.add_metadata(:custom, skip_nil: true) { nil }
+        metadata = @uploader.extract_metadata(fakeio)
+        assert !metadata.has_key?("custom")
+      end
+    end
+
     it "executes inside uploader and forwards correct arguments" do
       minitest = self
       input = fakeio


### PR DESCRIPTION
As discussed here: https://discourse.shrinerb.com/t/restrict-metadata-on-derivatives/175/6

I preferred to store definition options as a hash, so it can be expanded with other options later if needed. Please tell me if this suits you!