### PR TITLE
Add validation helper that check mime type with regexp

### DIFF
--- a/doc/plugins/validation_helpers.md
+++ b/doc/plugins/validation_helpers.md
@@ -48,6 +48,13 @@ validate_mime_type_exclusion %w[application/x-php]               # file must not
 Instead of `#validate_mime_type_inclusion` you can also use just
 `#validate_mime_type`.
 
+The `#validate_mime_type_format` method accepts a format of MIME type, and
+validate that the `mime_type` metadata value match that format.
+
+```rb
+validate_mime_type_format %r[\Aimage\/.+\z] # file must be a image
+```
+
 ### File extension
 
 The `#validate_extension_inclusion`/`#validation_extension_exclusion` methods
@@ -149,18 +156,19 @@ the `:default_messages` option to the plugin:
 
 ```rb
 plugin :validation_helpers, default_messages: {
-  max_size:            -> (max)  { I18n.t("errors.file.max_size", max: max) },
-  min_size:            -> (min)  { I18n.t("errors.file.min_size", min: min) },
-  max_width:           -> (max)  { I18n.t("errors.file.max_width", max: max) },
-  min_width:           -> (min)  { I18n.t("errors.file.min_width", min: min) },
-  max_height:          -> (max)  { I18n.t("errors.file.max_height", max: max) },
-  min_height:          -> (min)  { I18n.t("errors.file.min_height", min: min) },
-  max_dimensions:      -> (dims) { I18n.t("errors.file.max_dimensions", dims: dims) },
-  min_dimensions:      -> (dims) { I18n.t("errors.file.min_dimensions", dims: dims) },
-  mime_type_inclusion: -> (list) { I18n.t("errors.file.mime_type_inclusion", list: list) },
-  mime_type_exclusion: -> (list) { I18n.t("errors.file.mime_type_exclusion", list: list) },
-  extension_inclusion: -> (list) { I18n.t("errors.file.extension_inclusion", list: list) },
-  extension_exclusion: -> (list) { I18n.t("errors.file.extension_exclusion", list: list) },
+  max_size:            -> (max)    { I18n.t("errors.file.max_size", max: max) },
+  min_size:            -> (min)    { I18n.t("errors.file.min_size", min: min) },
+  max_width:           -> (max)    { I18n.t("errors.file.max_width", max: max) },
+  min_width:           -> (min)    { I18n.t("errors.file.min_width", min: min) },
+  max_height:          -> (max)    { I18n.t("errors.file.max_height", max: max) },
+  min_height:          -> (min)    { I18n.t("errors.file.min_height", min: min) },
+  max_dimensions:      -> (dims)   { I18n.t("errors.file.max_dimensions", dims: dims) },
+  min_dimensions:      -> (dims)   { I18n.t("errors.file.min_dimensions", dims: dims) },
+  mime_type_inclusion: -> (list)   { I18n.t("errors.file.mime_type_inclusion", list: list) },
+  mime_type_exclusion: -> (list)   { I18n.t("errors.file.mime_type_exclusion", list: list) },
+  mime_type_format:    -> (format) { "type must match #{format.inspect}" },
+  extension_inclusion: -> (list)   { I18n.t("errors.file.extension_inclusion", list: list) },
+  extension_exclusion: -> (list)   { I18n.t("errors.file.extension_exclusion", list: list) },
 }
 ```
 

--- a/lib/shrine/plugins/validation_helpers.rb
+++ b/lib/shrine/plugins/validation_helpers.rb
@@ -5,18 +5,19 @@ class Shrine
     # Documentation can be found on https://shrinerb.com/docs/plugins/validation_helpers
     module ValidationHelpers
       DEFAULT_MESSAGES = {
-        max_size:            -> (max)  { "size must not be greater than #{PRETTY_FILESIZE.call(max)}" },
-        min_size:            -> (min)  { "size must not be less than #{PRETTY_FILESIZE.call(min)}" },
-        max_width:           -> (max)  { "width must not be greater than #{max}px" },
-        min_width:           -> (min)  { "width must not be less than #{min}px" },
-        max_height:          -> (max)  { "height must not be greater than #{max}px" },
-        min_height:          -> (min)  { "height must not be less than #{min}px" },
-        max_dimensions:      -> (dims) { "dimensions must not be greater than #{dims.join("x")}" },
-        min_dimensions:      -> (dims) { "dimensions must not be less than #{dims.join("x")}" },
-        mime_type_inclusion: -> (list) { "type must be one of: #{list.join(", ")}" },
-        mime_type_exclusion: -> (list) { "type must not be one of: #{list.join(", ")}" },
-        extension_inclusion: -> (list) { "extension must be one of: #{list.join(", ")}" },
-        extension_exclusion: -> (list) { "extension must not be one of: #{list.join(", ")}" },
+        max_size:            -> (max)    { "size must not be greater than #{PRETTY_FILESIZE.call(max)}" },
+        min_size:            -> (min)    { "size must not be less than #{PRETTY_FILESIZE.call(min)}" },
+        max_width:           -> (max)    { "width must not be greater than #{max}px" },
+        min_width:           -> (min)    { "width must not be less than #{min}px" },
+        max_height:          -> (max)    { "height must not be greater than #{max}px" },
+        min_height:          -> (min)    { "height must not be less than #{min}px" },
+        max_dimensions:      -> (dims)   { "dimensions must not be greater than #{dims.join("x")}" },
+        min_dimensions:      -> (dims)   { "dimensions must not be less than #{dims.join("x")}" },
+        mime_type_inclusion: -> (list)   { "type must be one of: #{list.join(", ")}" },
+        mime_type_exclusion: -> (list)   { "type must not be one of: #{list.join(", ")}" },
+        mime_type_format:    -> (format) { "type must match #{format.inspect}" },
+        extension_inclusion: -> (list)   { "extension must be one of: #{list.join(", ")}" },
+        extension_exclusion: -> (list)   { "extension must not be one of: #{list.join(", ")}" },
       }.freeze
 
       FILESIZE_UNITS = ["B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"].freeze
@@ -185,6 +186,17 @@ class Shrine
           validate_result(
             !types.include?(file.mime_type),
             :mime_type_exclusion, message, types
+          )
+        end
+
+        # Validates that the `mime_type` metadata match the regular
+        # expression.
+        #
+        #     validate_mime_type_format %r[\Aimage\/.+\z]
+        def validate_mime_type_format(format, message: nil)
+          validate_result(
+            format.match(file.mime_type),
+            :mime_type_format, message, format
           )
         end
 


### PR DESCRIPTION
This is useful to check only top level type.
Also, similar libraries(Paperclip, CarrierWave) supports same format
validation. So this useful too when migration from other libraries.