### PR TITLE
Add GCS expires not to url_options

### DIFF
--- a/doc/plugins/url_options.md
+++ b/doc/plugins/url_options.md
@@ -10,6 +10,8 @@ storages.
 plugin :url_options, store: { expires_in: 24*60*60 }
 ```
 
+If you're using [GCS](https://googleapis.dev/ruby/google-cloud-storage/latest/Google/Cloud/Storage/File.html#signed_url-instance_method) you need `expires:` instead.
+
 You can also generate the default URL options dynamically by using a block,
 which will receive the UploadedFile object along with any options that were
 passed to `UploadedFile#url`.


### PR DESCRIPTION
For google cloud storage, the option is `expires` instead of S3's `expires_in`.