### PR TITLE
Add: instructions on how to run ruby templates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,6 +123,69 @@ post = Post.create(image: Down.download("https://example.com/image-from-internet
 # Your code for reproducing
 ```
 
+Appendix C: Running the Templates
+=================================
+ 
+You can either:
+
+* Create a Gemfile and add the necessary gems. 
+
+* Inline the required gems in the script - if you don't want to create a Gemfile.
+
+### Create a Gemfile and Add Gems (Option 1)
+
+```ruby
+# Gemfile
+source 'https://rubygems.org' do
+  gem "activerecord" # replace with gem "sequel" if you're using it
+  gem 'shrine'
+  gem "down"
+end
+```
+
+1. Run `bundle install` 
+2. Run the template with: `ruby template_name.rb`
+
+### In-lining them Gems in your script (Option 2)
+
+* Add the following to the above ****template script**** (not a Gemfile)
+
+```ruby
+## template_name.rb
+## Append the following to the top of the ruby template script
+require 'bundler/inline'
+
+gemfile do
+  source 'https://rubygems.org'
+  gem "activerecord" # replace with gem "sequel" if you're using it
+  gem 'shrine'
+end
+
+# include the rest of the template script below:
+```
+
+* Run the template with `ruby template_name.rb`.
+
+Appendix D: Debugging Shrine code
+=================================
+
+If you would like to debug or step through Shrine's code using the above template scripts, follow these steps:
+
+1. Download (or clone) Shrine's repository to your local machine
+   `git clone https://github.com/shrinerb/shrine.git` (or you could create a fork of the above repository and clone your fork - this will make it easier for you if you want to make a pull request). 
+2. Checkout the version of shrine you are using by running git checkout <version_tag> 
+3. Modify the Shrine gem line in your Gemfile to point to the local copy of Shrine code:
+
+```ruby
+  gem "shrine", path: "/path/to/your/local/shrine/gem/code" 
+```
+
+4. If needed, add a debugger like byebug or pry to the Gemfile.
+5. Run `bundle install`
+6. Add require "bundler/setup" to the top of the template script.
+7. You can add debugger statement anywhere in your template file or Shrine code 
+8. Run `ruby template_name.rb`. 
+
 [forum]: https://discourse.shrinerb.com
 [Shrine code of conduct]: https://github.com/shrinerb/shrine/blob/master/CODE_OF_CONDUCT.md
 [libmagic]: https://github.com/threatstack/libmagic


### PR DESCRIPTION
### What is this PR?

- New contributors might not know how to easily run the debugging templates (it took me a not insignificant time to learn how to do it). This PR adds instructions on how this can be done. Hopefully it will be of some use: if not, feel free discard it according to your discretion.

### What's the benefit of this PR?

* Hopefully this will lower the barriers to entry to new comers to help debug tests, and that will hopefully ease the maintenance burden for maintainers.