### PR TITLE
Enable options to trigger_mirror_upload to make e.g. resource and derivative name available

### DIFF
--- a/doc/plugins/mirroring.md
+++ b/doc/plugins/mirroring.md
@@ -50,7 +50,7 @@ Shrine.plugin :mirroring, mirror: { ... }, delete: false
 You can have mirroring performed in a background job:
 
 ```rb
-Shrine.mirror_upload_block do |file|
+Shrine.mirror_upload_block do |file, **options|
   MirrorUploadJob.perform_async(file.shrine_class.name, file.data)
 end
 

--- a/lib/shrine/plugins/mirroring.rb
+++ b/lib/shrine/plugins/mirroring.rb
@@ -85,7 +85,7 @@ class Shrine
           each_mirror do |mirror|
             rewind if opened?
 
-            shrine_class.upload(self, mirror, **options.merge(location: id, close: false, action: :mirror))
+            shrine_class.upload(self, mirror, **options, location: id, close: false, action: :mirror)
           end
         ensure
           if opened? && !previously_opened

--- a/test/plugin/mirroring_test.rb
+++ b/test/plugin/mirroring_test.rb
@@ -28,6 +28,14 @@ describe Shrine::Plugins::Mirroring do
 
         refute mirrored_file.exists?
       end
+
+      it "forwards options to the mirror upload" do
+        @shrine.expects(:upload).with do |file, mirror, **options|
+          mirror == :other_store && options[:foo] == "bar"
+        end
+
+        @uploader.upload(fakeio, foo: "bar")
+      end
     end
   end
 


### PR DESCRIPTION
This change allows options to be passed to trigger_mirror_upload, and then to upload. This way you can make e.g. the record en derivative name available to mirror upload. When combining this with the upload options plugin, you can make e.g. the record available there, for using it set S3 acl's.