### PR TITLE
Derivative processing normalization

### DIFF
--- a/doc/plugins/derivatives.md
+++ b/doc/plugins/derivatives.md
@@ -401,7 +401,8 @@ attacher.process_derivatives(:my_processor) # downloads attached file and passes
 
 If you want to use a different source file, you can pass it in to the process
 call. Typically you'd pass a local file on disk. If you pass a
-`Shrine::UploadedFile` object, it will be automatically downloaded to disk.
+`Shrine::UploadedFile` object or another IO-like object, it will be
+automatically downloaded/copied to a local TempFile on disk.
 
 ```rb
 # named processor:
@@ -420,6 +421,17 @@ attacher.file.download do |original|
   attacher.process_derivatives(:colors,     original)
 end
 ```
+
+If a processor would like to avoid the possibly expensive download/copy, becuase
+it does not require a local file copy, it can be registered with raw_source: true:
+
+```rb
+Attacher.derivatives :my_processor, raw_source: true do |source|
+  source #=> Could be File, Shrine::UploadedFile, or other IO-like object
+  shrine_class.with_file(source) do |file|
+    # can force download/copy if necessary with `with_file`,
+  end
+end
 
 ## Adding derivatives
 

--- a/lib/shrine/plugins/derivatives.rb
+++ b/lib/shrine/plugins/derivatives.rb
@@ -269,12 +269,8 @@ class Shrine
 
           source ||= file!
 
-          if source.is_a?(UploadedFile)
-            source.download do |file|
-              _process_derivatives(processor_name, file, **options)
-            end
-          else
-            _process_derivatives(processor_name, source, **options)
+          shrine_class.with_file(source) do |file|
+            _process_derivatives(processor_name, file, **options)
           end
         end
 

--- a/test/plugin/derivatives_test.rb
+++ b/test/plugin/derivatives_test.rb
@@ -812,6 +812,17 @@ describe Shrine::Plugins::Derivatives do
         assert_match /^#{Dir.tmpdir}/, result[:path].read
       end
 
+      it "downloads source non-file IO" do
+        @attacher.class.derivatives :path do |original|
+          { path: original.respond_to?(:path) ? StringIO.new(original.path) : nil }
+        end
+
+        result = @attacher.process_derivatives(:path, StringIO.new("fake content"))
+
+        assert result[:path]
+        assert_match /^#{Dir.tmpdir}/, result[:path].read
+      end
+
       it "forwards additional options" do
         @attacher.class.derivatives :options do |original, **options|
           { options: StringIO.new(options.to_s) }

--- a/test/plugin/derivatives_test.rb
+++ b/test/plugin/derivatives_test.rb
@@ -812,6 +812,17 @@ describe Shrine::Plugins::Derivatives do
         assert_match /^#{Dir.tmpdir}/, result[:path].read
       end
 
+      it "does not download source UploadedFile with raw_source" do
+        @attacher.class.derivatives :original_class, raw_source: true do |original|
+          { original_class: StringIO.new(original.class.inspect) }
+        end
+
+        file   = @attacher.upload(fakeio("file"))
+        result = @attacher.process_derivatives(:original_class, file)
+
+        assert_match /::UploadedFile\Z/, result[:original_class].read
+      end
+
       it "downloads source non-file IO" do
         @attacher.class.derivatives :path do |original|
           { path: original.respond_to?(:path) ? StringIO.new(original.path) : nil }
@@ -821,6 +832,16 @@ describe Shrine::Plugins::Derivatives do
 
         assert result[:path]
         assert_match /^#{Dir.tmpdir}/, result[:path].read
+      end
+
+      it "does not download source StringIO with raw_source" do
+        @attacher.class.derivatives :original_class, raw_source: true do |original|
+          { original_class: StringIO.new(original.class.inspect) }
+        end
+
+        result = @attacher.process_derivatives(:original_class, StringIO.new("stringIO"))
+
+        assert_equal "StringIO", result[:original_class].read
       end
 
       it "forwards additional options" do


### PR DESCRIPTION
By default ALL `sources` are converted to a local Tempfile before passing to derivative processor. This is done with `with_file` for consistency with other parts of shrine and DRY that logic. 

But option, when registering processor, `raw_source: true` is now available, which will just pass on the source-unaltered -- IO or UploadedFile, for the processor to choose to handle on it's own, in cases where the expense of downloading to localfile is not necessary (conditional logic, or something that can be processed without a local copy, etc). 

Would close #472, based on discussion there. 

Note that all existing shrine tests passed with this change; only new tests were added. I think this further supports my inclination to say that this is backwards compat, any behavior that was changed was undoc'd/untested/unconsidered before, and I consider buggy before and bug fixed here. 

But this might not yet be completely the right approach or implementation, feedback is quite welcome. Just thought it might be easier with some concrete code, so went ahead with it. 

I am not totally happy with how I'm storing the `raw_source` option in `opts[:derivatives][:processor_raw_source]`, but wanted to keep things very backwards compat so didn't want to touch existing `opts[:derivatives][:processors]`, so just did something simple. 