### PR TITLE
Fixes Ruby 2.7 arguments warnings

### DIFF
--- a/lib/shrine/plugins/backgrounding.rb
+++ b/lib/shrine/plugins/backgrounding.rb
@@ -36,8 +36,8 @@ class Shrine
 
       module AttacherMethods
         # Inherits global hooks if defined.
-        def initialize(*args)
-          super
+        def initialize(**args)
+          super(**args)
           @destroy_block = self.class.destroy_block
           @promote_block = self.class.promote_block
         end

--- a/test/plugin/upload_endpoint_test.rb
+++ b/test/plugin/upload_endpoint_test.rb
@@ -43,10 +43,10 @@ describe Shrine::Plugins::UploadEndpoint do
   end
 
   it "doesn't accept more than one file" do
-    response = app.post "/", multipart: HTTP::FormData.create("files[]": [
+    response = app.post "/", multipart: HTTP::FormData.create({ "files[]": [
       HTTP::FormData::File.new(image.path),
       HTTP::FormData::File.new(image.path),
-    ])
+    ] })
     assert_equal 400, response.status
     assert_equal "Too Many Files", response.body_binary
   end
@@ -84,7 +84,7 @@ describe Shrine::Plugins::UploadEndpoint do
 
   it "handles filenames with UTF-8 characters" do
     filename = "über_pdf_with_1337%_leetness.pdf"
-    form = HTTP::FormData.create(file: HTTP::FormData::Part.new("", filename: filename))
+    form = HTTP::FormData.create({ file: HTTP::FormData::Part.new("", filename: filename) })
     response = app.post "/", multipart: { input: form.to_s }, headers: {"Content-Type" => form.content_type}
     assert_equal 200, response.status
     uploaded_file = @shrine.uploaded_file(response.body_json)
@@ -183,9 +183,9 @@ describe Shrine::Plugins::UploadEndpoint do
 
   describe "Shrine.upload_response" do
     it "returns the Rack response triple" do
-      form_data = HTTP::FormData.create(
+      form_data = HTTP::FormData.create({
         file: HTTP::FormData::Part.new("content", filename: "foo.txt")
-      )
+      })
 
       env = {
         "REQUEST_METHOD" => "POST",
@@ -204,9 +204,9 @@ describe Shrine::Plugins::UploadEndpoint do
     end
 
     it "accepts additional upload endpoint options" do
-      form_data = HTTP::FormData.create(
+      form_data = HTTP::FormData.create({
         file: HTTP::FormData::Part.new("content", filename: "foo.txt")
-      )
+      })
 
       env = {
         "REQUEST_METHOD" => "POST",

--- a/test/shrine_test.rb
+++ b/test/shrine_test.rb
@@ -399,7 +399,7 @@ describe Shrine do
     end
 
     it "doesn't error when storage already closed the file" do
-      @uploader.storage.instance_eval { def upload(io, *); super; io.close; end }
+      @uploader.storage.instance_eval { def upload(io, id, **); super; io.close; end }
       @uploader.upload(fakeio)
     end
 

--- a/test/storage/linter_test.rb
+++ b/test/storage/linter_test.rb
@@ -18,7 +18,7 @@ describe Shrine::Storage::Linter do
     end
 
     it "takes into account that storage can modify location" do
-      @storage.instance_eval { def upload(io, id, *); id << "-modified"; super; end }
+      @storage.instance_eval { def upload(io, id, **); id << "-modified"; super; end }
       @linter.call
     end
   end
@@ -145,13 +145,13 @@ describe Shrine::Storage::Linter do
   end
 
   it "works for storages that close files on upload" do
-    @storage.instance_eval { def upload(io, id, *); super; io.close; end }
+    @storage.instance_eval { def upload(io, id, **); super; io.close; end }
     @linter.call
   end
 
   it "accounts for storages which cannot write immediately to previously used location" do
     @storage.instance_eval do
-      def upload(io, id, *)
+      def upload(io, id, **)
         @uploaded ||= []
         raise if @uploaded.include?(id)
         super
@@ -168,7 +168,7 @@ describe Shrine::Storage::Linter do
   end
 
   it "doesn't pass any file extensions" do
-    @storage.instance_eval { def upload(io, id, *); raise if id.include?("."); super; end }
+    @storage.instance_eval { def upload(io, id, **); raise if id.include?("."); super; end }
     @linter.call
   end
 end


### PR DESCRIPTION
I was seeing some Ruby 2.7 deprecation warnings in my app:

```
/Users/renchap/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/shrine-3.2.1/lib/shrine/plugins/backgrounding.rb:40: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/Users/renchap/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/shrine-3.2.1/lib/shrine/plugins/model.rb:91: warning: The called method `initialize' is defined here
```

Running the tests on my computer with Ruby 2.7.1 was showing some warnings as well (and the Travis build for 2.7 too), so I fixed all of them. I ran `bundle update` to get the latest `activesupport` / `actionrecord` versions fixing other warnings.

Related to #437