### PR TITLE
[#503] Fix Attacher marshalling with derivatives

### DIFF
--- a/lib/shrine/plugins/derivatives.rb
+++ b/lib/shrine/plugins/derivatives.rb
@@ -546,6 +546,31 @@ class Shrine
         def create_derivatives_on_promote?
           shrine_class.derivatives_options[:create_on_promote]
         end
+
+        # Support for proper marshalling
+        #
+        # It's impossible to marshal any models with this plugin
+        # as we can't marshal `Mutex` reliably.
+        def marshal_dump
+          instance_variables.reject do |name|
+            name == :@derivatives_mutex
+          end.map do |name|
+            [name, instance_variable_get(name)]
+          end
+        end
+
+        # Load marshalled instance
+        #
+        # We reload all instance variables, and re-create
+        # mutex. Otherwise the object won't function properly
+        def marshal_load(instance_variables)
+          instance_variables.each do |name, value|
+            instance_variable_set(name, value)
+          end
+
+          @derivatives_mutex = Mutex.new
+        end
+
       end
 
       module ClassMethods

--- a/test/integration/activerecord_derivatives_marshalling_test.rb
+++ b/test/integration/activerecord_derivatives_marshalling_test.rb
@@ -1,18 +1,24 @@
 require "test_helper"
-require "./test/support/sequel"
+require "./test/support/activerecord"
 
-describe "Sequel & derivatives marshalling" do
+describe "ActiveRecord & derivatives marshalling" do
   before do
     @shrine = shrine do
       plugin :sequel
       plugin :derivatives
     end
 
-    user_class = Class.new(Sequel::Model)
-    user_class.set_dataset(:users)
+    user_class = Class.new(ActiveRecord::Base)
+    user_class.table_name = :users
+    user_class.class_eval do
+      # needed for translating validation errors
+      def self.model_name
+        ActiveModel::Name.new(self, nil, "User")
+      end
+    end
     user_class.include @shrine::Attachment.new(:avatar)
 
-    @user = user_class.create
+    @user = user_class.create!
 
     # we can't Marshal anonymous classes
     Shrine::TestUploaderClass = @shrine
@@ -24,7 +30,7 @@ describe "Sequel & derivatives marshalling" do
     Shrine.send(:remove_const, :TestUploaderClass)
   end
 
-  specify "marshalling and unmarshalling don't raise any errors" do
+  specify "marshalling does not raise any errors" do
     Marshal.load(Marshal.dump(@user.avatar_attacher))
   end
 end

--- a/test/integration/derivatives_marshalling_test.rb
+++ b/test/integration/derivatives_marshalling_test.rb
@@ -1,0 +1,30 @@
+require "test_helper"
+require "./test/support/sequel"
+
+describe "Sequel & derivatives marshalling" do
+  before do
+    @shrine = shrine do
+      plugin :sequel
+      plugin :derivatives
+    end
+
+    user_class = Class.new(Sequel::Model)
+    user_class.set_dataset(:users)
+    user_class.include @shrine::Attachment.new(:avatar)
+
+    @user = user_class.create
+
+    # we can't Marshal anonymous classes
+    Shrine::TestUploaderClass = @shrine
+    Shrine::TestUserClass = user_class
+  end
+
+  after do
+    Shrine.send(:remove_const, :TestUserClass)
+    Shrine.send(:remove_const, :TestUploaderClass)
+  end
+
+  specify "marshalling and unmarshalling don't raise any errors" do
+    Marshal.load(Marshal.dump(@user.avatar_attacher))
+  end
+end


### PR DESCRIPTION
Addresses #503 

This is a pretty naïve implementation to support Ruby's built-in `Marshal` behavior

This is a functional pull-request, however I have a couple of concerns about this implementation:

1. The tests don't really test anything. I wanted to check for equality, but attacher doesn't implement it. It's okay though.
2. The main problem is that this marshalling won't work well with plugins.

If any other plugins needs a complex setup in `Attacher#initialize`, we may break it after marshalling.

It also doesn't compose too easily.

So I'm thinking about an alternative solution – perhaps it would be better to explicitly _disable_ marshalling? This way, people won't have to spend as much time debugging as I did, and they'll know they have to use/write a custom plugin for that.

I'd love your feedback @janko. I can join discourse if we need to discuss it