### PR TITLE
Change suggestion in migration in carrierwave.md

### DIFF
--- a/doc/carrierwave.md
+++ b/doc/carrierwave.md
@@ -275,8 +275,9 @@ Shrine. Let's assume we have a `Photo` model with the "image" attachment.
 First we need to create the `image_data` column for Shrine:
 
 ```rb
-add_column :photos, :image_data, :text # or :json or :jsonb if supported
+add_column :photos, :image_data, :text # please don't use :json or :jsonb here (even if supported) - this will result in errors during migration!
 ```
+
 
 ### 2. Dual write
 


### PR DESCRIPTION
Using the :json or :jsonb datatype for the migration form CarrierWave may result in errors.
The json-structure will be read as a string and then the "to_hash"-method is missing.
Using :text works fine. 
The errors are difficult to debug - took me 3 days to figure this out.
Please look into it.