### PR TITLE
Updates derivation_endpoint documentation

### DIFF
--- a/doc/processing.md
+++ b/doc/processing.md
@@ -315,20 +315,21 @@ previews.
 
 Shrine provides on-the-fly processing functionality via the
 **[`derivation_endpoint`][derivation_endpoint]** plugin. You set it up by
-loading the plugin with a secret key and a path prefix, mount its Rack app in
+loading the plugin with a secret key (you generate this yourself, maybe via
+something like SecureRandom.hex) and a path prefix, mount its Rack app in
 your routes on the configured path prefix, and define processing you want to
 perform:
 
 ```rb
 # config/initializers/shrine.rb (Rails)
 # ...
-Shrine.plugin :derivation_endpoint, secret_key: "<YOUR_SECRET_KEY>"
+Shrine.plugin :derivation_endpoint, secret_key: "<SHRINE_SECRET_KEY>"
 ```
 ```rb
 require "image_processing/mini_magick"
 
 class ImageUploader < Shrine
-  plugin :derivation_endpoint, prefix: "derivations/image" # matches mount point
+  plugin :derivation_endpoint, secret_key: ENV.fetch("SHRINE_SECRET_KEY"), prefix: "derivations/image" # matches mount point
 
   derivation :thumbnail do |file, width, height|
     ImageProcessing::MiniMagick

--- a/doc/processing.md
+++ b/doc/processing.md
@@ -316,7 +316,7 @@ previews.
 Shrine provides on-the-fly processing functionality via the
 **[`derivation_endpoint`][derivation_endpoint]** plugin. You set it up by
 loading the plugin with a secret key (you generate this yourself, maybe via
-something like SecureRandom.hex) and a path prefix, mount its Rack app in
+something like `SecureRandom.hex`) and a path prefix, mount its Rack app in
 your routes on the configured path prefix, and define processing you want to
 perform:
 
@@ -329,7 +329,7 @@ Shrine.plugin :derivation_endpoint, secret_key: "<SHRINE_SECRET_KEY>"
 require "image_processing/mini_magick"
 
 class ImageUploader < Shrine
-  plugin :derivation_endpoint, secret_key: ENV.fetch("SHRINE_SECRET_KEY"), prefix: "derivations/image" # matches mount point
+  plugin :derivation_endpoint, prefix: "derivations/image" # matches mount point
 
   derivation :thumbnail do |file, width, height|
     ImageProcessing::MiniMagick


### PR DESCRIPTION
* adds secret_key argument for derivation_endpoint plugin to docs
* renames and adds a note re: environment variable for clarity (i.e. you’re not using your Rails secret key)