### PR TITLE
Fix for "warning: Using the last argument as keyword parameters is deprecated"

### DIFF
--- a/lib/shrine.rb
+++ b/lib/shrine.rb
@@ -95,8 +95,8 @@ class Shrine
     #     class Photo
     #       include Shrine::Attachment(:image) # creates a Shrine::Attachment object
     #     end
-    def Attachment(name, *args)
-      self::Attachment.new(name, *args)
+    def Attachment(name, **args)
+      self::Attachment.new(name, **args)
     end
     alias attachment Attachment
     alias [] Attachment


### PR DESCRIPTION
Fixes https://github.com/shrinerb/shrine/issues/517