### PR TITLE
direct_s3.md: add JSON Bucket CORS config

### DIFF
--- a/doc/direct_s3.md
+++ b/doc/direct_s3.md
@@ -86,6 +86,30 @@ If you're using [Uppy], this is the recommended CORS configuration for the
 </CORSConfiguration>
 ```
 
+Or in JSON format:
+```json
+[
+    {
+        "AllowedOrigins": [ "https://my-app.com" ],
+        "AllowedMethods": [ "GET", "POST", "PUT" ],
+        "MaxAgeSeconds": 3000,
+        "AllowedHeaders": [
+            "Authorization",
+            "x-amz-date",
+            "x-amz-content-sha256",
+            "Content-Type",
+            "Content-Disposition"
+        ],
+        "ExposeHeaders": [ "ETag" ]
+    },
+    {
+        "AllowedOrigins": [ "*" ],
+        "AllowedMethods": [ "GET" ],
+        "MaxAgeSeconds": 3000
+    }
+]
+```
+
 Replace `https://my-app.com` with the URL to your app (in development you can
 set this to `*`). Once you've hit "Save", it may take some time for the
 new CORS settings to be applied.


### PR DESCRIPTION
It seems like they do not support XML format anymore in their new GUI