### PR TITLE
Fixes incorrect class reference in the “Adding new derivatives” docs.

### DIFF
--- a/doc/changing_derivatives.md
+++ b/doc/changing_derivatives.md
@@ -212,7 +212,7 @@ Photo.find_each do |photo|
   next unless attacher.stored?
 
   square = attacher.file.download do |original|
-    ImageProcessor::MiniMagick
+    ImageProcessing::MiniMagick
       .source(original)
       .resize_to_fill!(150, 150)
   end


### PR DESCRIPTION
The module seems to be incorrect and should be ImageProcessing instead.