### PR TITLE
[#539] Fixes error in mime type given to svgs by fastimage

### DIFF
--- a/lib/shrine/plugins/determine_mime_type.rb
+++ b/lib/shrine/plugins/determine_mime_type.rb
@@ -124,6 +124,8 @@ class Shrine
           require "fastimage"
 
           type = FastImage.type(io)
+          return 'image/svg+xml' if type == :svg
+
           "image/#{type}" if type
         end
 

--- a/test/plugin/determine_mime_type_test.rb
+++ b/test/plugin/determine_mime_type_test.rb
@@ -76,6 +76,18 @@ describe Shrine::Plugins::DetermineMimeType do
       assert_equal "image/jpeg", @shrine.determine_mime_type(image)
     end
 
+    it "returns image/svg+xml if the image is an svg" do
+      io = StringIO.new
+      io.puts <<-SVG
+        <svg xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg" xml:space="preserve" version="1.1" viewBox="0 0 20 20">
+          <g>
+            <path d="M0.567016+10.1229L19.267+10.1229"/>
+          </g>
+        </svg>
+        SVG
+      assert_equal "image/svg+xml", @shrine.determine_mime_type(io)
+    end
+
     it "returns nil for unidentified MIME types" do
       assert_nil @shrine.determine_mime_type(fakeio("😃"))
     end


### PR DESCRIPTION
https://github.com/shrinerb/shrine/issues/539

The determine_mime_type plugin returns the incorrect mime type
for svgs when using the fastimage analyzer. This is because fastimage
is returning a symbol `:svg` as the type, and Shrine is doing a
string interpolation to return `image/` plus whatever fastimage returns.

The correct mime type for svgs is `image/svg+xml`, which requires a
special case in this method since simple string interpolation won't
handle it. So I've added a return value for `image/svg+xml` for this
case.

The SVG in my test is just a straight line that I made in a vector editor.