### PR TITLE
Add `infer_extension` convenience method to uploader

### DIFF
--- a/lib/shrine/plugins/infer_extension.rb
+++ b/lib/shrine/plugins/infer_extension.rb
@@ -51,6 +51,10 @@ class Shrine
       end
 
       module InstanceMethods
+        def infer_extension(mime_type)
+          self.class.infer_extension(mime_type)
+        end
+
         private
 
         def basic_location(io, metadata:)

--- a/test/plugin/infer_extension_test.rb
+++ b/test/plugin/infer_extension_test.rb
@@ -151,4 +151,9 @@ describe Shrine::Plugins::InferExtension do
       @shrine.infer_extension("image/png")
     end
   end
+
+  it "can infer extension both from instance and class level" do
+    assert_instance_of String, @uploader.infer_extension("image/png")
+    assert_instance_of String, @shrine.infer_extension("image/png")
+  end
 end


### PR DESCRIPTION
Same as `calculate_signature`. For a discussion (well, monologue) see [this discourse](https://discourse.shrinerb.com/t/how-to-call-infer-extension-in-custom-plugin-when-defined-as-a-dependency/502/2?u=aried3r).

Just a proposal, doesn't add anything but convenience and maybe more concise code. So if you don't think it should be exposed like this, feel free to just close this. :)