### PR TITLE
Correct usage of #atomic_persist when backgrounding

### DIFF
--- a/doc/changing_location.md
+++ b/doc/changing_location.md
@@ -99,11 +99,12 @@ class MoveFilesJob
 
     attacher     = attacher_class.retrieve(model: record, name: name, file: file_data)
     old_attacher = attacher.dup
+    current_file = old_attacher.file
 
     attacher.set             attacher.upload(attacher.file)
     attacher.set_derivatives attacher.upload_derivatives(attacher.derivatives)
 
-    attacher.atomic_persist
+    attacher.atomic_persist(current_file)
     old_attacher.destroy_attached
   rescue Shrine::AttachmentChanged, ActiveRecord::RecordNotFound
     attacher&.destroy_attached


### PR DESCRIPTION
I added `current_file` just like https://github.com/shrinerb/shrine/commit/12b3e25b81000451e8429fceb7337501da60610b.