### PR TITLE
S3 should use tagging_directive REPLACE on copy operation

### DIFF
--- a/lib/shrine/storage/s3.rb
+++ b/lib/shrine/storage/s3.rb
@@ -232,7 +232,11 @@ class Shrine
       # Copies an existing S3 object to a new location. Uses multipart copy for
       # large files.
       def copy(io, id, **copy_options)
-        options = { metadata_directive: "REPLACE" } # don't inherit source object metadata
+        # don't inherit source object metadata or AWS tags
+        options = {
+          metadata_directive: "REPLACE",
+          tagging_directive: "REPLACE"
+        }
 
         if io.size && io.size >= @multipart_threshold[:copy]
           # pass :content_length on multipart copy to avoid an additional HEAD request

--- a/test/storage/s3_test.rb
+++ b/test/storage/s3_test.rb
@@ -201,6 +201,14 @@ describe Shrine::Storage::S3 do
         assert_equal "REPLACE",    @s3.client.api_requests[0][:params][:metadata_directive]
       end
 
+      it "adds directive for replacing object tagging" do
+        uploaded_file = @shrine.uploaded_file(id: "bar", storage: "s3", metadata: { "size" => 10 })
+        @s3.upload(uploaded_file, "foo")
+        assert_equal :copy_object, @s3.client.api_requests[0][:operation_name]
+        assert_equal "REPLACE",    @s3.client.api_requests[0][:params][:tagging_directive]
+      end
+
+
       it "forwards any upload options" do
         uploaded_file = @shrine.uploaded_file(id: "bar", storage: "s3", metadata: { "size" => 10 })
         @s3.upload(uploaded_file, "foo", acl: "public-read")


### PR DESCRIPTION
It was always using metadata_directive: REPLACE; this does not apply to AWS tags applied to an S3 object. It should also use tagging_directive to apply to AWS tags as well.

This makes it so tags aren't copied when copying from (say) cache to storage. More significantly, it allows the caller to pass S3 `tagging` param in `upload_options`, and have this take effect, whether on a promotion or any other kind of `upload`, regardless of whether the S3 adapter decides to use a `copy_from` operation under the hood.

Without this change, whether `tagging` passed as `upload_options` actually works (as well as whether the destination winds up with copied tags from source) depends on whether the S3 adapter decides to use `copy_from`, which should be an implementation detail that does not effect outcomes.

More at https://discourse.shrinerb.com/t/gotcha-on-s3-upload-options-and-tags/559
