### PR TITLE
Customize max multipart part

### DIFF
--- a/test/storage/s3_test.rb
+++ b/test/storage/s3_test.rb
@@ -134,6 +134,17 @@ describe Shrine::Storage::S3 do
         ], @s3.client.api_requests.map { |r| r[:operation_name] }
       end unless RUBY_ENGINE == "jruby" # randomly fails on JRuby
 
+      it "limits upload part when max multipart part is set" do
+        @s3 = s3(multipart_threshold: { upload: 5*1024*1024 }, max_multipart_parts: 1)
+        @s3.upload(fakeio("a" * 6*1024*1024), "foo")
+
+        assert_equal [
+          :create_multipart_upload,
+          :upload_part,
+          :complete_multipart_upload,
+        ], @s3.client.api_requests.map { |r| r[:operation_name] }
+      end unless RUBY_ENGINE == "jruby" # randomly fails on JRuby
+
       it "respects :prefix" do
         @s3 = s3(multipart_threshold: { upload: 1}, prefix: "prefix")
         @s3.upload(fakeio, "foo")


### PR DESCRIPTION
Some s3 compatible cloud providers limit the number of multipart part during upload (example scaleway : https://www.scaleway.com/en/docs/storage/object/api-cli/multipart-uploads/).

This PR adds an options on the S3 driver to override the default max multipart part set to 10_000.