### PR TITLE
Allow encoding to be specified with S3 storage class

### DIFF
--- a/test/storage/s3_test.rb
+++ b/test/storage/s3_test.rb
@@ -328,6 +328,12 @@ describe Shrine::Storage::S3 do
       assert_raises(IOError) { io.rewind }
     end
 
+    it "accepts :encoding option" do
+      @s3.client.stub_responses(:get_object, status_code: 200, headers: { "content-length" => "7" }, body: "content")
+      io = @s3.open("foo", encoding: 'UTF-8')
+      assert_equal Encoding::UTF_8, io.read().encoding
+    end
+
     it "returns Shrine::FileNotFound when object was not found" do
       @s3.client.stub_responses(:get_object, "NoSuchKey")
       assert_raises(Shrine::FileNotFound) { @s3.open("nonexisting") }


### PR DESCRIPTION
When using local file storage with Shrine, a call to `#read` will accept `encoding: ...` in the same way as one might expect for a regular IO object. This is quite important when dealing with input data for things like CSV which might come from all manner of sources, including correctly-encoded UTF-8 with or without BOM, ISO8859-1 or (quite often) Windows CP1252.

In our application, we used this to figure out the encoding and decode the CSV accordingly, but while it works for local development where file storage is convenient for most engineers, it didn't work in deployment since the S3 storage class didn't understand that option and just passed it through to the AWS SDK, which understandably complained.

This PR fixes that in a backwards-compatible way by accepting a with-nil-default encoding option and passing it to the `Down::ChunkedIO` constructor. The updated tests pass with the patch present, else fail with:

```
  1) Failure:
Shrine::Storage::S3::#open#test_0007_accepts :encoding option [...shrine/test/storage/s3_test.rb:334]:
Expected: #<Encoding:UTF-8>
  Actual: #<Encoding:ASCII-8BIT>
```

That's not the end of the story, unfortunately! When Shrine is _actually_ (out of tests) driving the `Down::ChunkedIO` object, it calls `#read` on the instance and passes a buffer length. For some reason, if and only if a buffer length is given, Down currently ignores the encoding that it's been given. This is addressed by https://github.com/janko/down/pull/74, which will hopefully be merged soon.

In the mean time, this PR for Shrine is harmless and beneficial if either using a monkey-patched Down gem (as we currently are, as well as monkey patched Shrine!) or using a future Down gem release with the above PR merged.