### PR TITLE
Fix "warning: URI.regexp is obsolete"

### DIFF
--- a/lib/shrine/uploaded_file.rb
+++ b/lib/shrine/uploaded_file.rb
@@ -50,7 +50,7 @@ class Shrine
       # The extension derived from #id if present, otherwise it's derived
       # from #original_filename.
       def extension
-        identifier = id =~ URI.regexp ? id.sub(/\?.+$/, "") : id # strip query params for shrine-url
+        identifier = id =~ URI::DEFAULT_PARSER.make_regexp ? id.sub(/\?.+$/, "") : id # strip query params for shrine-url
         result = File.extname(identifier)[1..-1]
         result ||= File.extname(original_filename.to_s)[1..-1]
         result.downcase if result


### PR DESCRIPTION
`URI.regexp` is obsolete now.

```
$ ruby -w -e 'require "net/http"; URI.regexp'
-e:1: warning: URI.regexp is obsolete
```

This changed to use `URI::DEFAULT_PARSER.make_regexp` that use inside `URI.regexp`
instead of `URI.regexp`.
https://github.com/ruby/uri/blob/6bc8f666219e519c1001673c15adab5182ff05ef/lib/uri/common.rb#L294-L297