### PR TITLE
Correct small typo in doc/plugins/derivatives.md

### DIFF
--- a/doc/plugins/derivatives.md
+++ b/doc/plugins/derivatives.md
@@ -133,7 +133,7 @@ Attacher.default_url do |derivative: nil, **|
 end
 ```
 ```rb
-photo.image_url(:medium) #=> "https://example.com/fallbacks.com/medium.jpg"
+photo.image_url(:medium) #=> "https://example.com/fallbacks/medium.jpg"
 ```
 
 Any additional URL options passed to `#<name>_url` will be forwarded to the


### PR DESCRIPTION
The URL will be /fallbacks/ not /fallbacks.com/ (probably a bad find/replace/copy/paste of example.com