### PR TITLE
Include detected file mime type in validate_mime_type_inclusion errors

### DIFF
--- a/lib/shrine/plugins/validation_helpers.rb
+++ b/lib/shrine/plugins/validation_helpers.rb
@@ -13,7 +13,10 @@ class Shrine
         min_height:          -> (min)  { "height must not be less than #{min}px" },
         max_dimensions:      -> (dims) { "dimensions must not be greater than #{dims.join("x")}" },
         min_dimensions:      -> (dims) { "dimensions must not be less than #{dims.join("x")}" },
-        mime_type_inclusion: -> (list) { "type must be one of: #{list.join(", ")}" },
+        mime_type_inclusion: lambda do |list, type|
+          mime_type = type.nil? || type == "" ? "no" : type
+          "type must be one of: #{list.join(", ")}, (#{mime_type} content type detected)"
+        end,
         mime_type_exclusion: -> (list) { "type must not be one of: #{list.join(", ")}" },
         extension_inclusion: -> (list) { "extension must be one of: #{list.join(", ")}" },
         extension_exclusion: -> (list) { "extension must not be one of: #{list.join(", ")}" },
@@ -172,7 +175,7 @@ class Shrine
         def validate_mime_type_inclusion(types, message: nil)
           validate_result(
             types.include?(file.mime_type),
-            :mime_type_inclusion, message, types
+            :mime_type_inclusion, message, types, file.mime_type
           )
         end
         alias validate_mime_type validate_mime_type_inclusion
@@ -230,9 +233,9 @@ class Shrine
 
         # Returns the direct message if given, otherwise uses the default error
         # message.
-        def error_message(type, message, object)
+        def error_message(type, message, *args)
           message ||= self.class.default_validation_messages.fetch(type)
-          message.is_a?(String) ? message : message.call(object)
+          message.is_a?(String) ? message : message.call(*args)
         end
       end
     end


### PR DESCRIPTION
#### Problem 

The default error message of `validate_mime_type_inclusion` can be confusing to the end user. 

To give a specific recent example, we validate mime type to be `text/csv`. When a user uploads a CSV file that looks perfectly fine but includes an `<html>` tag, Marcel will identify the file as `text/html`.

To replicate:

```ruby
string = StringIO.new("a,b,c,d,e,<html>data</html>")
Marcel::MimeType.for(string, name: "test.csv")
# => "text/html"
```

Without providing feedback as to what mime type was detected, the user will be unaware what's wrong with their data.csv file when the error they see is _File type must be one of: text/csv_.

There is currently no way to provide a custom error message with the detected mime type other than writing a custom plugin.

#### Changes

Include the detected mime type in the default validation error message. This way, the user can review the file and clean it up. In the example above, any HTML in the CSV is undesirable and will cause issues downstream.

Error before: _type must be one of: text/csv_
Error after:
-  _type must be one of: text/csv, (text/html content type detected)_
-  _type must be one of: text/csv, (no content type detected)_

#### Considerations

`validate_mime_type_exclusion` could be updated the same way. However, the message makes more sense in this case (e.g. the file can't be `image/jpeg` but somehow it is `image/jpeg`.

Some documentation could be added about defining a custom message (expecting 2 arguments, not 1) but I wanted to collect initial feedback first.