### PR TITLE
fix: search bar on Docusaurus site

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -105,6 +105,7 @@ module.exports = {
     algolia: {
       appId: "KBFWBJ5DPX",
       apiKey: "31cb4225120fdce1d852b8566680e816",
+      contextualSearch: false,
       indexName: "shrinerb"
     }
   }


### PR DESCRIPTION
### What is this?

* Close: #646.
* Search bar was not working.

### What does done?

I just changed a config setting, as described here: https://discourse.algolia.com/t/algolia-searchbar-is-not-working-with-docusaurus-v2/14659

all of a sudden the search bar is working:  ![development_server_is_working](https://github.com/shrinerb/shrine/assets/15097447/6e5b3e8c-fccf-4d40-8700-29706f8e698d)

(I am guessing you will need to rebuild / re-index the site etc. I know very little about Docusaurus, pls take all of this with a grain of salt.)




