### PR TITLE
Make Shrine::DataFile truly top-level citizen

### DIFF
--- a/lib/shrine.rb
+++ b/lib/shrine.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "shrine/data_file"
 require "shrine/uploaded_file"
 require "shrine/attacher"
 require "shrine/attachment"

--- a/lib/shrine/data_file.rb
+++ b/lib/shrine/data_file.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "forwardable"
+
+class Shrine
+  # IO-like object from string.
+  class DataFile
+    extend Forwardable
+
+    attr_reader :content_type, :original_filename
+
+    delegate %i[read size rewind eof?] => :@io
+
+    def initialize(content, content_type: nil, filename: nil)
+      @content_type      = content_type
+      @original_filename = filename
+      @io                = StringIO.new(content)
+    end
+
+    def to_io
+      @io
+    end
+
+    def close
+      @io.close
+      @io.string.clear # deallocate string
+    end
+  end
+end

--- a/lib/shrine/plugins/data_uri.rb
+++ b/lib/shrine/plugins/data_uri.rb
@@ -4,7 +4,6 @@ require "base64"
 require "strscan"
 require "cgi"
 require "stringio"
-require "forwardable"
 
 class Shrine
   module Plugins
@@ -151,27 +150,5 @@ class Shrine
     end
 
     register_plugin(:data_uri, DataUri)
-  end
-
-  class DataFile
-    attr_reader :content_type, :original_filename
-
-    def initialize(content, content_type: nil, filename: nil)
-      @content_type      = content_type
-      @original_filename = filename
-      @io                = StringIO.new(content)
-    end
-
-    def to_io
-      @io
-    end
-
-    extend Forwardable
-    delegate [:read, :size, :rewind, :eof?] => :@io
-
-    def close
-      @io.close
-      @io.string.clear # deallocate string
-    end
   end
 end


### PR DESCRIPTION
`Shrine::DataFile` is already a top-level citizen, but available only of data uri plugin is loaded. For one use case I need to use DataFile directly when passing it to `assign` (creating attachment from the raw string), and this will allow do just that.