### PR TITLE
Duplicate the context hash when duplicating an Attacher

### DIFF
--- a/lib/shrine/attacher.rb
+++ b/lib/shrine/attacher.rb
@@ -341,6 +341,13 @@ class Shrine
 
       private
 
+      # The copy constructor that's called on #dup and #clone
+      # We need to duplicate the context to prevent it from being shared
+      def initialize_copy(other)
+        super
+        @context = @context.dup
+      end
+
       # Converts a String or Hash value into an UploadedFile object and ensures
       # it's uploaded to temporary storage.
       #

--- a/test/attacher_test.rb
+++ b/test/attacher_test.rb
@@ -6,6 +6,13 @@ describe Shrine::Attacher do
     @shrine   = @attacher.shrine_class
   end
 
+  describe '#initialize_copy' do
+    it 'duplicates the context when duplicating the attacher' do
+      attacher_copy = @attacher.dup
+      refute_equal @attacher.context.object_id, attacher_copy.context.object_id
+    end
+  end
+
   describe ".from_data" do
     it "instantiates an attacher from file data" do
       file     = @attacher.upload(fakeio)

--- a/test/plugin/model_test.rb
+++ b/test/plugin/model_test.rb
@@ -136,6 +136,7 @@ describe Shrine::Plugins::Model do
         assert_equal model_copy, model_copy.file_attacher.record
         assert_equal :file, model_copy.file_attacher.name
         assert_equal Hash[record: model_copy, name: :file], model_copy.file_attacher.context
+        assert_equal Hash[record: model, name: :file], model.file_attacher.context
         assert model_copy.file_attacher.changed? # retains any state
       end
 


### PR DESCRIPTION
We hit an issue following the upgrade to 3.5.0 where `context[:record]` in an `Attacher#finalize` call was set to an unpersisted duplicate of the record we were saving. This turned out to be because another part of our model save flow was duplicating the model for its own purposes and the `context` hash was shared between the original attacher and its duplicate.

The changes in fc6a3ed70aab9bff51ec1f0d269ad9553f4b8145  added a call to `attacher_copy.set_entity(self, name) if attacher_copy`. Because `@context` in both attachers point at the same object, this ends up with `context[:record]` for both records pointing to the new duplicate model. 