### PR TITLE
UploadedFile#close should leave uploaded_file in a state where #opened? is false

### DIFF
--- a/lib/shrine/uploaded_file.rb
+++ b/lib/shrine/uploaded_file.rb
@@ -170,6 +170,7 @@ class Shrine
       # opened IO object.
       def close
         io.close if opened?
+        @io = nil
       end
 
       # Returns whether the file has already been opened.

--- a/test/plugin/rack_response_test.rb
+++ b/test/plugin/rack_response_test.rb
@@ -106,8 +106,11 @@ describe Shrine::Plugins::RackResponse do
     uploaded_file = @uploader.upload(fakeio)
     uploaded_file.open
     response = uploaded_file.to_rack_response
+
+    existing_io = uploaded_file.to_io
+
     response[2].close
-    assert uploaded_file.to_io.closed?
+    assert existing_io.closed?
   end
 
   it "returns ranged responses when :range is given" do

--- a/test/uploaded_file_test.rb
+++ b/test/uploaded_file_test.rb
@@ -241,6 +241,14 @@ describe Shrine::UploadedFile do
       uploaded_file.storage.expects(:open).never
       uploaded_file.close
     end
+
+    it "leaves the UploadedFile no longer #opened?" do
+      uploaded_file = @uploader.upload(fakeio)
+      uploaded_file.open
+      uploaded_file.close
+
+      refute uploaded_file.opened?
+    end
   end
 
   describe "#url" do


### PR DESCRIPTION
This means removing the reference to the now-closed (and unusable) IO object. Which meant refactoring an existing test slightly, as it tried to refer to the IO object after UploadedFile#close.

## Use case where I encountered this

Normally you can call UploadedFile#download without having previously opened, it takes care of it. 

```ruby
tmpfile = uploaded_file.download
# it works
```

*AND* normally you can open and close an UploadedFile multiple times, no problem. 

```ruby
uploaded_file.open
# do things
uploaded_file.close

uploaded_file.open
# do things
uploaded_file.close
# no problem
```

BUT if you have first opened and closed an UploadedFile THEN try to call #download, it complains -- and it's because the UploadedFile actually still thinks it's #opened?

```ruby
uploaded_file.open
uploaded_file.close

uploaded_file.opened? # => true !!!?! this seems wrong

uploaded_file.download
# RAISES `ruby/3.2.2/gems/down-5.4.1/lib/down/chunked_io.rb:157:in `readpartial': closed stream (IOError)
```

This is because `close` leaves the UploadedFile in an inconsistent state where it's underlying `io` is closed, BUT the UploadedFile still thinks it's `opened`, which [#stream uses](https://github.com/shrinerb/shrine/blob/b586fb2e8e64ef2b8b213a069ec4576f07c3d8d4/lib/shrine/uploaded_file.rb#L143) to assume the underlying IO is in fact readable. 

The solution seems to be making sure `#close` leaves the UploadedFile in a symmetrical state as if it had never been `open`ed in the first place -- that is, unset the `@io` to `nil`, which will make it no longer [opened?](https://github.com/shrinerb/shrine/blob/b586fb2e8e64ef2b8b213a069ec4576f07c3d8d4/lib/shrine/uploaded_file.rb#L176-L178)

*NOTE* if you use #open in it's block arg form, it already was nil'ing out `@io`. This further supports the idea it's a bugfix to make `close` do so too.  https://github.com/shrinerb/shrine/blob/b586fb2e8e64ef2b8b213a069ec4576f07c3d8d4/lib/shrine/uploaded_file.rb#L102

## Backwards compat?

The fact that I also had to change that test for rake made me nervous -- is it a backwards incompat to make `uploaded_file.to_io` no longer refer to the closed `io` object after `close`? 

But I can't think of any actual use case for this OTHER than a test like this -- why would you ever  want `to_io` to return a closed unusable IO object?  I think this was a bug all along, and is a bug fix, and anything relying on the previous behavior was relying on buggy behavior -- but it's very unlikely anything was, I can't think of any use case for wanting a closed unusable IO object back from `to_io`! 
