### PR TITLE
Use lower case constants for headers (fixes Rack > 2 applications)

### DIFF
--- a/doc/plugins/rack_response.md
+++ b/doc/plugins/rack_response.md
@@ -20,10 +20,10 @@ status, headers, body = uploaded_file.to_rack_response
 status  #=> 200
 headers #=>
 # {
-#   "Content-Length"      => "100",
-#   "Content-Type"        => "text/plain",
-#   "Content-Disposition" => "inline; filename=\"file.txt\"",
-#   "Accept-Ranges"       => "bytes"
+#   "content-length"      => "100",
+#   "content-type"        => "text/plain",
+#   "content-disposition" => "inline; filename=\"file.txt\"",
+#   "accept-ranges"       => "bytes"
 # }
 body    # object that responds to #each and #close
 ```
@@ -53,33 +53,33 @@ directly from the storage. It also works with [Rack::Sendfile] when using
 
 ## Type
 
-The response `Content-Type` header will default to the value of the `mime_type`
+The response `content-type` header will default to the value of the `mime_type`
 metadata. A custom content type can be provided via the `:type` option:
 
 ```rb
 response = uploaded_file.to_rack_response(type: "text/plain; charset=utf-8")
-response[1]["Content-Type"] #=> "text/plain; charset=utf-8"
+response[1]["content-type"] #=> "text/plain; charset=utf-8"
 ```
 
 ## Filename
 
-The download filename in the `Content-Disposition` header will default to the
+The download filename in the `content-disposition` header will default to the
 value of the `filename` metadata. A custom download filename can be provided
 via the `:filename` option:
 
 ```rb
 response = uploaded_file.to_rack_response(filename: "my-filename.txt")
-response[1]["Content-Disposition"] #=> "inline; filename=\"my-filename.txt\""
+response[1]["content-disposition"] #=> "inline; filename=\"my-filename.txt\""
 ```
 
 ## Disposition
 
-The default disposition in the "Content-Disposition" header is `inline`, but it
+The default disposition in the "content-disposition" header is `inline`, but it
 can be changed via the `:disposition` option:
 
 ```rb
 response = uploaded_file.to_rack_response(disposition: "attachment")
-response[1]["Content-Disposition"] #=> "attachment; filename=\"file.txt\""
+response[1]["content-disposition"] #=> "attachment; filename=\"file.txt\""
 ```
 
 ## Range
@@ -90,8 +90,8 @@ which accepts a value of the `Range` request header.
 ```rb
 status, headers, body = uploaded_file.to_rack_response(range: env["HTTP_RANGE"])
 status                    #=> 206
-headers["Content-Length"] #=> "101"
-headers["Content-Range"]  #=> "bytes 100-200/1000"
+headers["content-length"] #=> "101"
+headers["content-range"]  #=> "bytes 100-200/1000"
 body                      # partial content
 ```
 

--- a/lib/shrine/plugins/download_endpoint.rb
+++ b/lib/shrine/plugins/download_endpoint.rb
@@ -113,7 +113,11 @@ class Shrine
         handle_request(request)
       end
 
-      headers["Content-Length"] ||= body.map(&:bytesize).inject(0, :+).to_s
+      if Rack.release > "2"
+        headers["content-length"] ||= body.map(&:bytesize).inject(0, :+).to_s
+      else
+        headers["Content-Length"] ||= body.map(&:bytesize).inject(0, :+).to_s
+      end
 
       [status, headers, body]
     end
@@ -151,8 +155,12 @@ class Shrine
         range:       request.env["HTTP_RANGE"],
       )
 
-      response[1]["Cache-Control"] = "max-age=#{365*24*60*60}" # cache for a year
-
+      if Rack.release > "2"
+        response[1]["cache-control"] = "max-age=#{365*24*60*60}" # cache for a year
+      else
+        response[1]["Cache-Control"] = "max-age=#{365*24*60*60}" # cache for a year
+      end
+      
       response
     end
 
@@ -164,7 +172,11 @@ class Shrine
         redirect_url = @redirect.call(uploaded_file, request)
       end
 
-      [302, { "Location" => redirect_url }, []]
+      if Rack.release > "2"
+        [302, { "location" => redirect_url }, []]
+      else
+        [302, { "Location" => redirect_url }, []]
+      end
     end
 
     def open_file(uploaded_file, request)
@@ -197,7 +209,11 @@ class Shrine
 
     # Halts the request with the error message.
     def error!(status, message)
-      throw :halt, [status, { "Content-Type" => "text/plain" }, [message]]
+      if Rack.release > "2"
+        throw :halt, [status, { "content-type" => "text/plain" }, [message]]
+      else
+        throw :halt, [status, { "Content-Type" => "text/plain" }, [message]]
+      end
     end
   end
 end

--- a/lib/shrine/plugins/presign_endpoint.rb
+++ b/lib/shrine/plugins/presign_endpoint.rb
@@ -91,7 +91,11 @@ class Shrine
         end
       end
 
-      headers["Content-Length"] ||= body.map(&:bytesize).inject(0, :+).to_s
+      if Rack.release > "2"
+        headers["content-length"] ||= body.map(&:bytesize).inject(0, :+).to_s
+      else
+        headers["Content-Length"] ||= body.map(&:bytesize).inject(0, :+).to_s
+      end
 
       [status, headers, body]
     end
@@ -161,18 +165,30 @@ class Shrine
       if @rack_response
         response = @rack_response.call(object, request)
       else
-        response = [200, { "Content-Type" => CONTENT_TYPE_JSON }, [object.to_json]]
+        if Rack.release > "2"
+          response = [200, { "content-type" => CONTENT_TYPE_JSON }, [object.to_json]]
+        else
+          response = [200, { "Content-Type" => CONTENT_TYPE_JSON }, [object.to_json]]
+        end
       end
 
       # prevent browsers from caching the response
-      response[1]["Cache-Control"] = "no-store" unless response[1].key?("Cache-Control")
+      if Rack.release > "2"
+        response[1]["cache-control"] = "no-store" unless response[1].key?("cache-control")
+      else
+        response[1]["Cache-Control"] = "no-store" unless response[1].key?("Cache-Control")
+      end
 
       response
     end
 
     # Used for early returning an error response.
     def error!(status, message)
-      throw :halt, [status, { "Content-Type" => CONTENT_TYPE_TEXT }, [message]]
+      if Rack.release > "2"
+        throw :halt, [status, { "content-type" => CONTENT_TYPE_TEXT }, [message]]
+      else
+        throw :halt, [status, { "Content-Type" => CONTENT_TYPE_TEXT }, [message]]
+      end
     end
 
     # Returns the uploader around the specified storage.

--- a/lib/shrine/plugins/rack_response.rb
+++ b/lib/shrine/plugins/rack_response.rb
@@ -48,14 +48,25 @@ class Shrine
         # metadata. Also returns the correct "Content-Range" header on ranged
         # requests.
         def rack_headers(filename: nil, type: nil, disposition: "inline", range: false)
-          {
-            "Content-Length"      => content_length(range),
-            "Content-Type"        => content_type(type),
-            "Content-Disposition" => content_disposition(disposition, filename),
-            "Content-Range"       => content_range(range),
-            "Accept-Ranges"       => accept_ranges(range),
-            "ETag"                => etag,
-          }.compact
+          if Rack.release > "2"
+            {
+              "content-length" => content_length(range),
+              "content-type" => content_type(type),
+              "content-disposition" => content_disposition(disposition, filename),
+              "content-range" => content_range(range),
+              "accept-ranges" => accept_ranges(range),
+              "etag" => etag
+            }.compact
+          else
+            {
+              "Content-Length" => content_length(range),
+              "Content-Type" => content_type(type),
+              "Content-Disposition" => content_disposition(disposition, filename),
+              "Content-Range" => content_range(range),
+              "Accept-Ranges" => accept_ranges(range),
+              "ETag" => etag
+            }.compact
+          end
         end
 
         # Value for the "Content-Length" header.

--- a/lib/shrine/plugins/upload_endpoint.rb
+++ b/lib/shrine/plugins/upload_endpoint.rb
@@ -91,7 +91,11 @@ class Shrine
         handle_request(request)
       end
 
-      headers["Content-Length"] ||= body.map(&:bytesize).inject(0, :+).to_s
+      if Rack.release > "2"
+        headers["content-length"] ||= body.map(&:bytesize).inject(0, :+).to_s
+      else
+        headers["Content-Length"] ||= body.map(&:bytesize).inject(0, :+).to_s
+      end
 
       [status, headers, body]
     end
@@ -180,7 +184,11 @@ class Shrine
           body = uploaded_file.to_json
         end
 
-        [200, { "Content-Type" => CONTENT_TYPE_JSON }, [body]]
+        if Rack.release > "2"
+          [200, { "content-type" => CONTENT_TYPE_JSON }, [body]]
+        else
+          [200, { "Content-Type" => CONTENT_TYPE_JSON }, [body]]
+        end
       end
     end
 
@@ -210,7 +218,11 @@ class Shrine
 
     # Used for early returning an error response.
     def error!(status, message)
-      throw :halt, [status, { "Content-Type" => CONTENT_TYPE_TEXT }, [message]]
+      if Rack.release > "2"
+        throw :halt, [status, { "content-type" => CONTENT_TYPE_TEXT }, [message]]
+      else
+        throw :halt, [status, { "Content-Type" => CONTENT_TYPE_TEXT }, [message]]
+      end
     end
 
     # Returns the uploader around the specified storage.


### PR DESCRIPTION
On Rack 3 https://github.com/rack/rack/issues/1592, it was decided to lowercase all response headers. Thus, all logic in the codebase that checks for headers coming from Rack > 2 applications is broken.

This PR:

* Uses lower case constants for headers.
* It does so by checking `Rack.release > "2"` so that we keep compatibility with Rack 2.x and 1.6.x.
  * This introduces `if` statements that look a bit ugly, but that was the pattern I found was being used within the codebase. 

# Note

I'm yet to write some specs for this but wanted to get this draft out for potential discussion.