### PR TITLE
Fix file iterator bytesize fetch (fixes Rack > 2 applications)

### DIFF
--- a/lib/shrine/plugins/derivation_endpoint.rb
+++ b/lib/shrine/plugins/derivation_endpoint.rb
@@ -365,7 +365,14 @@ class Shrine
         handle_request(request)
       end
 
-      headers["Content-Length"] ||= body.map(&:bytesize).inject(0, :+).to_s
+      if Rack.release >= "2.1"
+        headers["Content-Length"] ||= body.byesize.to_s
+      else
+        sum = 0
+        body.each { |chunk| sum += chunk.bytesize }
+
+        headers["Content-Length"] = sum.to_s
+      end
 
       [status, headers, body]
     end

--- a/lib/shrine/plugins/download_endpoint.rb
+++ b/lib/shrine/plugins/download_endpoint.rb
@@ -113,7 +113,14 @@ class Shrine
         handle_request(request)
       end
 
-      headers["Content-Length"] ||= body.map(&:bytesize).inject(0, :+).to_s
+      if Rack.release >= "2.1"
+        headers["Content-Length"] ||= body.byesize.to_s
+      else
+        sum = 0
+        body.each { |chunk| sum += chunk.bytesize }
+
+        headers["Content-Length"] = sum.to_s
+      end
 
       [status, headers, body]
     end

--- a/lib/shrine/plugins/presign_endpoint.rb
+++ b/lib/shrine/plugins/presign_endpoint.rb
@@ -91,7 +91,14 @@ class Shrine
         end
       end
 
-      headers["Content-Length"] ||= body.map(&:bytesize).inject(0, :+).to_s
+      if Rack.release >= "2.1"
+        headers["Content-Length"] ||= body.byesize.to_s
+      else
+        sum = 0
+        body.each { |chunk| sum += chunk.bytesize }
+
+        headers["Content-Length"] = sum.to_s
+      end
 
       [status, headers, body]
     end

--- a/lib/shrine/plugins/upload_endpoint.rb
+++ b/lib/shrine/plugins/upload_endpoint.rb
@@ -91,7 +91,14 @@ class Shrine
         handle_request(request)
       end
 
-      headers["Content-Length"] ||= body.map(&:bytesize).inject(0, :+).to_s
+      if Rack.release >= "2.1"
+        headers["Content-Length"] ||= body.byesize.to_s
+      else
+        sum = 0
+        body.each { |chunk| sum += chunk.bytesize }
+
+        headers["Content-Length"] = sum.to_s
+      end
 
       [status, headers, body]
     end


### PR DESCRIPTION
Neither `Rack::Files` nor `Rack::File` have ever responded to `#map`, but they always have responded to `#each`, so we should use that instead.

Also, on Rack >= 2.1, `Rack::Files::Iterator#bytesize` was introduced, avoiding the need to calculate it ourselves.

This broken behavior was discovered on a Rack 3 application. The fact that Rack already populated the `Content-Length` header (`content-length` now) was hiding this broken fallback implementation. https://github.com/shrinerb/shrine/pull/660 would fix the broken behavior, by appropriately fetching the downcased header coming from Rack 3 applications, but would keep hiding the broken fallback behavior.

This PR fixes the fallback behavior to use the correct method, depending on the Rack version used.

# Note

I'm still writing specs for this, but wanted to get the draft up for potential discussion.