### PR TITLE
forward options when calling #promote_cached to promote_block

### DIFF
--- a/lib/shrine/plugins/backgrounding.rb
+++ b/lib/shrine/plugins/backgrounding.rb
@@ -69,7 +69,7 @@ class Shrine
         # Does a background promote if promote block was registered.
         def promote_cached(**options)
           if promote? && promote_block
-            promote_background
+            promote_background(**options)
           else
             super
           end

--- a/test/plugin/backgrounding_test.rb
+++ b/test/plugin/backgrounding_test.rb
@@ -124,6 +124,22 @@ describe Shrine::Plugins::Backgrounding do
         assert @attacher.stored?
       end
 
+      it "forwards additional options to the block" do
+        @attacher.promote_block do |attacher, **options|
+          @job = Fiber.new { attacher.promote(**options) }
+        end
+
+        @attacher.attach_cached(fakeio)
+        @attacher.promote_cached(location: "foo")
+
+        assert @attacher.cached?
+
+        @job.resume
+
+        assert @attacher.stored?
+        assert_equal "foo", @attacher.file.id
+      end
+
       it "calls default promotion when no promote blocks are registered" do
         @attacher.attach_cached(fakeio)
         @attacher.promote_cached


### PR DESCRIPTION
If `Shrine::Attacher.promote_block { |**options| ... }` is declared with backgrounding plugin and we call `attacher.promote_cached(**options)`, the options were not being forwarded to the `.promote_block`.