### PR TITLE
add custom etag option to rack_response plugin

### DIFF
--- a/lib/shrine/plugins/rack_response.rb
+++ b/lib/shrine/plugins/rack_response.rb
@@ -49,14 +49,14 @@ class Shrine
         # "Content-Disposition" headers, whose values are extracted from
         # metadata. Also returns the correct "Content-Range" header on ranged
         # requests.
-        def rack_headers(filename: nil, type: nil, disposition: "inline", range: false)
+        def rack_headers(filename: nil, type: nil, disposition: "inline", range: false, custom_etag: nil)
           {
             "Content-Length"      => content_length(range),
             "Content-Type"        => content_type(type),
             "Content-Disposition" => content_disposition(disposition, filename),
             "Content-Range"       => content_range(range),
             "Accept-Ranges"       => accept_ranges(range),
-            "ETag"                => etag,
+            "ETag"                => custom_etag || etag,
           }.compact
         end
 

--- a/test/plugin/rack_response_test.rb
+++ b/test/plugin/rack_response_test.rb
@@ -232,6 +232,13 @@ describe Shrine::Plugins::RackResponse do
     assert_equal etags, etags.uniq
   end
 
+  it "allows custom ETAG value" do
+    uploaded_file = @uploader.upload(fakeio)
+    response = uploaded_file.to_rack_response(custom_etag: "VeryCustomETAG")
+    assert_instance_of String,    response[1]["ETag"]
+    assert_match "VeryCustomETAG", response[1]["ETag"]
+  end
+
   it "implements #to_path on the body for filesystem storage" do
     uploaded_file = @uploader.upload(fakeio)
     response = uploaded_file.to_rack_response


### PR DESCRIPTION
The `rack_response` plugin ETAG response header is generated based on attributes that can remain the same even if the file content has been changed.

```ruby
        # Value for the "ETag" header.
        def etag
          digest = Digest::SHA256.hexdigest("#{file.shrine_class}-#{file.storage_key}-#{file.id}")

          %(W/"#{digest.byteslice(0, 32)}")
        end
```

This may result in unwanted response caching.