### PR TITLE
Fix method call to use attacher's abstract_persist in atomic_helpers

### DIFF
--- a/lib/shrine/plugins/atomic_helpers.rb
+++ b/lib/shrine/plugins/atomic_helpers.rb
@@ -76,7 +76,11 @@ class Shrine
 
             yield attacher if block_given?
 
-            abstract_persist(persist)
+            if attacher
+              attacher.abstract_persist(persist)
+            else
+              abstract_persist(persist)
+            end
           end
         end
 


### PR DESCRIPTION
### Bug Description

The issue arises when using backgrounding for promoting files. During promotion, the attacher does not fetch the latest version of the record from the database and instead operates with an outdated version. This causes the record's state to be inconsistent, especially when using background jobs like in Sidekiq.

### Example

Here's an example where the issue occurs:

```ruby
video = Video.new
video.update(state: 'pending')
# Waiting for the video to be uploaded 
video.update(image: file)
video.update(state: 'success')
```

When promoting the file in the background using a job, the state of the record is not updated correctly.

```ruby
class PromoteJob
  include Sidekiq::Worker

  def perform(attacher_class, record_class, record_id, name, file_data)
    ...
    record = Object.const_get(record_class).find(record_id)
    # At this point, "record.state == 'pending'"

    attacher = attacher_class.retrieve(model: record, name: name, file: file_data)
    attacher.atomic_promote
  end
end
```

### Root Cause

In the current implementation of `abstract_atomic_persist`, even though the attacher reloads the record with the most up-to-date data, the old version of `self.record` is still being used, which causes the inconsistency. The fix is to make sure that the newly reloaded attacher is used when persisting the record.

### Suggested Fix

In `Shrine::Plugins::AtomicHelpers::AttacherMethods`, the following change was made to ensure the correct attacher is persisted:

```ruby
module Shrine::Plugins::AtomicHelpers::AttacherMethods
  .....

  def abstract_atomic_persist(original_file = file, reload:, persist:)
    # The record is refreshed and already contains the current values
    abstract_reload(reload) do |attacher|
      ........
      # At this step, "attacher.record.state == 'success'"
      # but self.record.state == 'pending'

      -- abstract_persist(persist)
      ++ attacher.abstract_persist(persist)
    end
  end

  # Calls the reload strategy and yields a reloaded attacher from the
  # reloaded record.
  def abstract_reload(strategy)
    ....

    strategy.call do |record|
      reloaded_attacher = dup

      # The new record is defined in the copy
      reloaded_attacher.load_entity(record, name)

      yield reloaded_attacher
    end
  end
  .....
end
```

### Outcome

This change ensures that after the record is reloaded, the updated attacher (which now has the correct state) is used to persist the final state of the record, preventing issues where the record state is outdated when performing background promotions.
