### PR TITLE
Add Replace argument to refresh_metadata! in RefreshMetadata plugin

### DIFF
--- a/doc/plugins/refresh_metadata.md
+++ b/doc/plugins/refresh_metadata.md
@@ -69,5 +69,25 @@ Any options passed in will be forwarded to metadata extraction:
 uploaded_file.refresh_metadata!(foo: "bar") # passes `{ foo: "bar" }` options to metadata extraction
 ```
 
+## Replacing Metadata
+
+By default the `#refresh_metadata!` method will merge the results into any existing metadata.
+
+```rb
+  uploaded_file.metadata["custom"] = "custom value"
+  uploaded_file.refresh_metadata!
+  uploaded_file.metadata
+  # returns {"filename"=>"example.jpg", "size"=>1024, "mime_type"=>"image/jpeg", "custom"=>"custom value"}
+```
+
+Passing `replace: true` will instead fully overwrite the existing metadata with the new metadata.
+
+```rb
+  uploaded_file.metadata["custom"] = "custom value"
+  uploaded_file.refresh_metadata!(replace: true)
+  uploaded_file.metadata
+  # returns {"filename"=>"example.jpg", "size"=>1024, "mime_type"=>"image/jpeg"}
+```
+
 [refresh_metadata]: https://github.com/shrinerb/shrine/blob/master/lib/shrine/plugins/refresh_metadata.rb
 [model]: https://shrinerb.com/docs/plugins/model

--- a/lib/shrine/plugins/refresh_metadata.rb
+++ b/lib/shrine/plugins/refresh_metadata.rb
@@ -12,12 +12,12 @@ class Shrine
       end
 
       module FileMethods
-        def refresh_metadata!(**options)
-          return open { refresh_metadata!(**options) } unless opened?
+        def refresh_metadata!(replace: false, **options)
+          return open { refresh_metadata!(replace: replace, **options) } unless opened?
 
           refreshed_metadata = uploader.send(:get_metadata, self, metadata: true, **options)
 
-          @metadata = @metadata.merge(refreshed_metadata)
+          @metadata = replace ? refreshed_metadata : @metadata.merge(refreshed_metadata)
         end
       end
     end

--- a/test/plugin/refresh_metadata_test.rb
+++ b/test/plugin/refresh_metadata_test.rb
@@ -88,6 +88,15 @@ describe Shrine::Plugins::RefreshMetadata do
         file.refresh_metadata!(foo: "bar")
       end
 
+      it "overwrites all metadata when replace is true" do
+        file = @uploader.upload(fakeio("content"))
+        file.metadata["size"]= 100
+        file.metadata["custom"] = "custom"
+        file.refresh_metadata!(replace: true)
+        refute_includes file.metadata.keys, "custom"
+        assert_equal 7, file.metadata["size"]
+      end
+
       it "doesn't re-open an already open uploaded file" do
         file = @uploader.upload(fakeio("content"))
         file.metadata.delete("size")


### PR DESCRIPTION
Currently `refresh_metadata!` merges the results of `Shrine.get_metadata` with the existing metadata. This means that when used in conjunction with the `add_metadata` plugin it doesn't handle changes that would remove unused or "deprecated" metadata.

For example, if the uploader previously looked like this

```rb

class ImageUploader < Shrine

  add_metadata :example_metadata do |io, context|
    'my custom metadata'
  end

  Attacher.derivatives do |original|
    {
      thumbnail:  ImageProcessing::Vips.source(original).resize_to_fill!(200, 200),
    }
  end
end
```
but was later updated to not add `example_metadata` to derivatives
```rb

class ImageUploader < Shrine

  add_metadata :example_metadata, skip_nil: true do |io, context|
    next nil if context[:derivative]

    'my custom metadata'
  end

  Attacher.derivatives do |original|
    {
      thumbnail:  ImageProcessing::Vips.source(original).resize_to_fill!(200, 200),
    }
  end
end
```
we end up with not changes after calling `refresh_metadata!` even though it would be reasonable to expect it to remove the `example_metadata`.

```rb
  uploaded_file(:thumbnail).metadata
  # {"filename"=>"example.jpg", "size"=>1024, "mime_type"=>"image/jpeg", "example_metadata"=>"my custom metadata"}
  uploaded_file(:thumbnail).refresh_metadata!(derivative: :thumbnail)
  uploaded_file(:thumbnail).metadata
  # {"filename"=>"example.jpg", "size"=>1024, "mime_type"=>"image/jpeg", "example_metadata"=>"my custom metadata"}
```

Now we can set `replace: true` to fully overwrite the existing metadata with the results of `Shrine.get_metadata`.

```rb
  uploaded_file(:thumbnail).metadata
  # {"filename"=>"example.jpg", "size"=>1024, "mime_type"=>"image/jpeg", "example_metadata"=>"my custom metadata"}
  uploaded_file(:thumbnail).refresh_metadata!(replace: true, derivative: :thumbnail)
  uploaded_file(:thumbnail).metadata
  # {"filename"=>"example.jpg", "size"=>1024, "mime_type"=>"image/jpeg"}
```

I would also be interested in looking at a way to handle automatically refreshing the metadata of any derivatives when `Shrine::Attacher.refresh_metadata!` is called, if the derivatives plugin is included. But I couldn't think of the best way to go about this.
