### PR TITLE
Add parentheses to method call to fix warning

### DIFF
--- a/lib/shrine/plugins/remote_url.rb
+++ b/lib/shrine/plugins/remote_url.rb
@@ -110,7 +110,7 @@ class Shrine
         # Generates an error message for failed remote URL download.
         def remote_url_error_message(url, error)
           message = shrine_class.opts[:remote_url][:error_message]
-          message = message.call *[url, error].take(message.arity.abs) if message.respond_to?(:call)
+          message = message.call(*[url, error].take(message.arity.abs)) if message.respond_to?(:call)
           message || "download failed: #{error.message}"
         end
       end


### PR DESCRIPTION
# Fix Ruby 3+ splat operator warning in remote_url plugin

```bash
/Users/sbastien/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/shrine-3.6.0/lib/shrine/plugins/remote_url.rb:113: warning: `*' interpreted as argument prefix
```

## Description

This PR addresses a warning that appears in Ruby 3+ when using the splat operator (`*`) in the `remote_url_error_message` method. The warning occurs because Ruby 3+ has become more strict about the usage of the splat operator to avoid ambiguity between multiplication and argument splatting.

## Changes

- Updated the splat operator usage in `remote_url_error_message` to use explicit parentheses

## Testing
- The functionality remains unchanged
- The warning is no longer present in Ruby 3+
- All existing tests should continue to pass