### PR TITLE
Fixed URI default parser warnings

### DIFF
--- a/lib/shrine/uploaded_file.rb
+++ b/lib/shrine/uploaded_file.rb
@@ -22,6 +22,8 @@ class Shrine
     end
 
     module InstanceMethods
+      RFC2396_PARSER = URI::RFC2396_Parser.new
+
       # The location where the file was uploaded to the storage.
       attr_reader :id
 
@@ -50,7 +52,7 @@ class Shrine
       # The extension derived from #id if present, otherwise it's derived
       # from #original_filename.
       def extension
-        identifier = id =~ URI::DEFAULT_PARSER.make_regexp ? id.sub(/\?.+$/, "") : id # strip query params for shrine-url
+        identifier = id =~ RFC2396_PARSER.make_regexp ? id.sub(/\?.+$/, "") : id # strip query params for shrine-url
         result = File.extname(identifier)[1..-1]
         result ||= File.extname(original_filename.to_s)[1..-1]
         result.downcase if result


### PR DESCRIPTION
Necessary to resolve the following warnings showing up in output:

----
lib/shrine/uploaded_file.rb:53: warning: URI::RFC3986_PARSER.make_regexp is obsolete. Use URI::RFC2396_PARSER.make_regexp explicitly. ----

This introduces the `RFC2396_PARSER` constant which has an instance of `URI::RFC2396_Parser.new` instead of using `URI::RFC3986_PARSER` directly since `URI::RFC3986_PARSER` was only introduced in the URI gem recently but `URI::RFC2396_Parser` has been around since link:https://docs.ruby-lang.org/en/2.2.0/URI/RFC2396_Parser.html[Ruby 2.2.0] which improves backwards compatibility.

The above can replicated with `$VERBOSE = true` and/or with RSpec warnings enabled.

Issue: 725
Milestone: patch