### PR TITLE
Fix "Called deprecated method `upload_stream`" when using S3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * `download_endpoint` - Add support for expiring URLs
 
+* `s3` - Use `TransferManager` where available instead of deprecated `upload_steam` (@danieldevlewis)
+
 ## 3.6.0 (2024-04-29)
 
 * Add Rack 3 support (@tomasc, @janko)


### PR DESCRIPTION
A fix for the deprecation warnings AWS S3 deprecation warning:

```
Called deprecated method `upload_stream` of Aws::S3::Object. Use `Aws::S3::TransferManager#upload_stream` instead.
```

Mostly I just copied what Rails did here https://github.com/rails/rails/pull/55541/files.  As far as I can tell the behaviour should be identical.

This supports the old and new S3 gems, although the tests are only going to cover the latest version of the gem.