### PR TITLE
Don't attempt to deserialize data column if it's an empty string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * `s3` - Use `TransferManager` where available instead of deprecated `upload_steam` (@danieldevlewis)
 
+* `column` - Don't attempt to deserialize empty string as JSON (@adam12)
+
 ## 3.6.0 (2024-04-29)
 
 * Add Rack 3 support (@tomasc, @janko)

--- a/lib/shrine/plugins/column.rb
+++ b/lib/shrine/plugins/column.rb
@@ -75,6 +75,8 @@ class Shrine
         #     Attacher.deserialize_column(nil)
         #     #=> nil
         def deserialize_column(data)
+          return nil if data == ""
+
           if column_serializer && data && !data.is_a?(Hash)
             column_serializer.load(data)
           else

--- a/test/plugin/column_test.rb
+++ b/test/plugin/column_test.rb
@@ -61,6 +61,13 @@ describe Shrine::Plugins::Column do
       assert_nil @attacher.file
     end
 
+    it "clears file when empty string is given" do
+      @attacher.attach(fakeio)
+      @attacher.load_column("")
+
+      assert_nil @attacher.file
+    end
+
     it "handles hashes" do
       file = @attacher.attach(fakeio)
       @attacher.load_column(file.data)


### PR DESCRIPTION
When the column consists of an empty string, a JSON::ParserError is raised.

Instead of attempting to deserialize the empty string, just return nil.

Closes #718