### PR TITLE
Add keep_derivatives option to derivatives plugin to keep derivatives when attaching a new file

### DIFF
--- a/lib/shrine/plugins/derivatives.rb
+++ b/lib/shrine/plugins/derivatives.rb
@@ -459,9 +459,13 @@ class Shrine
         #     attacher.derivatives #=> { thumb: #<Shrine::UploadedFile> }
         #     attacher.change(file)
         #     attacher.derivatives #=> {}
+        #
+        #     # With keep_derivatives: true
+        #     attacher.change(file)
+        #     attacher.derivatives #=> { thumb: #<Shrine::UploadedFile> }
         def change(*)
           result = super
-          set_derivatives({})
+          set_derivatives({}) unless shrine_class.derivatives_options[:keep_derivatives]
           result
         end
 

--- a/test/plugin/derivatives_test.rb
+++ b/test/plugin/derivatives_test.rb
@@ -1270,6 +1270,20 @@ describe Shrine::Plugins::Derivatives do
         assert_equal file,     @attacher.file
       end
 
+      it "does not clear derivatives if keep_derivatives is set" do
+        @shrine.derivatives_options[:keep_derivatives] = true
+
+        @attacher.attach(fakeio)
+        @attacher.add_derivatives({ one: fakeio })
+        old = @attacher.derivatives.dup
+
+        file = @attacher.upload(fakeio)
+        @attacher.change(file)
+
+        assert_equal old,  @attacher.derivatives
+        assert_equal file, @attacher.file
+      end
+
       it "records previous derivatives" do
         file        = @attacher.attach(fakeio)
         derivatives = @attacher.add_derivatives({ one: fakeio })


### PR DESCRIPTION
see #723

There is only one minimal test :/