### PR TITLE
Forward promote options to derivatives

### DIFF
--- a/lib/shrine/plugins/derivatives.rb
+++ b/lib/shrine/plugins/derivatives.rb
@@ -161,7 +161,7 @@ class Shrine
         #     attacher.stored?(attacher.derivatives[:thumb]) #=> true
         def promote(**options)
           super
-          promote_derivatives
+          promote_derivatives(**options)
           create_derivatives if create_derivatives_on_promote?
         end
 

--- a/test/plugin/derivatives_test.rb
+++ b/test/plugin/derivatives_test.rb
@@ -327,6 +327,17 @@ describe Shrine::Plugins::Derivatives do
         assert_equal "foo", @attacher.file.id
       end
 
+      it "forwards promote options to derivatives" do
+        @shrine.plugin :upload_options, store: -> (_io, options) { { foo: options[:foo] } }
+
+        @attacher.attach_cached(fakeio)
+        @attacher.add_derivative(:one, fakeio, storage: :cache)
+
+        @shrine.storages[:store].expects(:upload).twice.with { |*, options| options[:foo] == "bar" }
+
+        @attacher.promote(foo: "bar")
+      end
+
       it "works with backgrounding plugin" do
         @attacher = attacher do
           plugin :backgrounding


### PR DESCRIPTION
## Summary

- Forward `Attacher#promote` keyword options to `promote_derivatives` in the derivatives plugin.
- Add a regression test covering upload options applied to both the main file and cached derivatives during promotion.

## Why

`promote_derivatives` already accepts and forwards upload options, but `promote` dropped them when calling it. This caused storage-level upload options to apply to the main file while being lost for promoted derivatives.

Fixes #745.

## Test

- `CI=1 BUNDLE_PATH=/private/tmp/shrine-bundle bundle exec rake test`