### PR TITLE
Add :max_size option to data_uri plugin

### DIFF
--- a/doc/plugins/data_uri.md
+++ b/doc/plugins/data_uri.md
@@ -37,18 +37,22 @@ attachment column. You can change the default error message:
 ```rb
 plugin :data_uri, error_message: "data URI was invalid"
 plugin :data_uri, error_message: ->(uri) { I18n.t("errors.data_uri_invalid") }
+plugin :data_uri, error_message: ->(uri, error) { I18n.t("errors.data_uri.#{error.message}") }
 ```
 
 ## Maximum size
 
-The `:max_size` option sets the maximum allowed size of the decoded content.
-The size is determined from the encoded payload, so oversized content is
-rejected before it gets decoded into memory. Parsing fails the same way as
-for a malformed URI:
+It's a good practice to limit the maximum size of the data URI content:
 
 ```rb
 plugin :data_uri, max_size: 10*1024*1024 # 10 MB
 ```
+
+Now if content bigger than 10MB is assigned, parsing will fail the same way as
+for an invalid data URI. The size is calculated from the data URI before the
+content is decoded, so oversized content never gets loaded into memory. It's
+exact for base64 content, while for percent-encoded content the encoded length
+is used, which can overestimate.
 
 ## Uploader options
 

--- a/doc/plugins/data_uri.md
+++ b/doc/plugins/data_uri.md
@@ -39,6 +39,17 @@ plugin :data_uri, error_message: "data URI was invalid"
 plugin :data_uri, error_message: ->(uri) { I18n.t("errors.data_uri_invalid") }
 ```
 
+## Maximum size
+
+The `:max_size` option sets the maximum allowed size of the decoded content.
+The size is determined from the encoded payload, so oversized content is
+rejected before it gets decoded into memory. Parsing fails the same way as
+for a malformed URI:
+
+```rb
+plugin :data_uri, max_size: 10*1024*1024 # 10 MB
+```
+
 ## Uploader options
 
 Any options passed to `Attacher#assign_data_uri` will be forwarded to

--- a/lib/shrine/plugins/data_uri.rb
+++ b/lib/shrine/plugins/data_uri.rb
@@ -17,6 +17,7 @@ class Shrine
       BASE64_REGEXP        = /;base64/
       CONTENT_SEPARATOR    = /,/
       DEFAULT_CONTENT_TYPE = "text/plain"
+      BASE64_ALPHABET      = "A-Za-z0-9+/"
 
       LOG_SUBSCRIBER = -> (event) do
         Shrine.logger.info "Data URI (#{event.duration}ms) – #{{
@@ -61,7 +62,6 @@ class Shrine
         def data_uri(uri, filename: nil)
           instrument_data_uri(uri) do
             info = parse_data_uri(uri)
-            verify_data_size!(info)
             create_data_file(info, filename: filename)
           end
         end
@@ -79,34 +79,37 @@ class Shrine
           data_file
         end
 
-        # Fails if the decoded content would exceed the configured :max_size.
-        # The size is determined from the encoded payload, so oversized
-        # content is rejected before it gets decoded into memory.
-        def verify_data_size!(info)
+        # Raises `ParseError` if the content exceeds the `:max_size` option.
+        def verify_data_size!(uri, offset, base64)
           max_size = opts[:data_uri][:max_size]
           return unless max_size
 
-          raise ParseError, "data URI is too large" if data_size(info) > max_size
+          size = data_size(uri, offset, base64)
+
+          raise ParseError, "data URI is too large" if size > max_size
         end
 
-        # Byte size of the payload after decoding, calculated without
-        # decoding it. Counting base64 alphabet characters keeps the result
-        # exact for line-wrapped (MIME-style) payloads as well.
-        def data_size(info)
-          if info[:base64]
-            info[:data].count("A-Za-z0-9+/") * 3 / 4
-          else
-            info[:data].bytesize - info[:data].count("%") * 2
-          end
+        # Returns the size the content will have once decoded. It's exact for
+        # base64 and an upper bound for percent-encoded content.
+        def data_size(uri, offset, base64)
+          return uri.bytesize - offset unless base64
+
+          header_characters  = uri.byteslice(0, offset).count(BASE64_ALPHABET)
+          content_characters = uri.count(BASE64_ALPHABET) - header_characters
+
+          content_characters * 3 / 4 # 4 characters decode into 3 bytes
         end
 
-        # Parses the data URI string and returns parts.
+        # Parses the data URI string, verifies content size, and returns parts.
         def parse_data_uri(uri)
           scanner = StringScanner.new(uri)
           scanner.scan(DATA_REGEXP) or raise ParseError, "data URI has invalid format"
           media_type = scanner.scan(MEDIA_TYPE_REGEXP)
           base64 = scanner.scan(BASE64_REGEXP)
           scanner.scan(CONTENT_SEPARATOR) or raise ParseError, "data URI has invalid format"
+
+          verify_data_size!(scanner.string, scanner.pos, base64)
+
           content = scanner.post_match
 
           { content_type: media_type, base64: !!base64, data: content }
@@ -151,7 +154,7 @@ class Shrine
         # Generates an error message for failed data URI parse.
         def data_uri_error_messsage(uri, error)
           message = shrine_class.opts[:data_uri][:error_message]
-          message = message.call(uri) if message.respond_to?(:call)
+          message = message.call(*[uri, error].take(message.arity.abs)) if message.respond_to?(:call)
           message || error.message
         end
       end

--- a/lib/shrine/plugins/data_uri.rb
+++ b/lib/shrine/plugins/data_uri.rb
@@ -61,6 +61,7 @@ class Shrine
         def data_uri(uri, filename: nil)
           instrument_data_uri(uri) do
             info = parse_data_uri(uri)
+            verify_data_size!(info)
             create_data_file(info, filename: filename)
           end
         end
@@ -76,6 +77,27 @@ class Shrine
           info[:data].clear
 
           data_file
+        end
+
+        # Fails if the decoded content would exceed the configured :max_size.
+        # The size is determined from the encoded payload, so oversized
+        # content is rejected before it gets decoded into memory.
+        def verify_data_size!(info)
+          max_size = opts[:data_uri][:max_size]
+          return unless max_size
+
+          raise ParseError, "data URI is too large" if data_size(info) > max_size
+        end
+
+        # Byte size of the payload after decoding, calculated without
+        # decoding it. Counting base64 alphabet characters keeps the result
+        # exact for line-wrapped (MIME-style) payloads as well.
+        def data_size(info)
+          if info[:base64]
+            info[:data].count("A-Za-z0-9+/") * 3 / 4
+          else
+            info[:data].bytesize - info[:data].count("%") * 2
+          end
         end
 
         # Parses the data URI string and returns parts.

--- a/test/plugin/data_uri_test.rb
+++ b/test/plugin/data_uri_test.rb
@@ -123,6 +123,39 @@ describe Shrine::Plugins::DataUri do
         assert_equal 0,  io.size
       end
 
+      it "refuses content larger than :max_size" do
+        @shrine.plugin :data_uri, max_size: 6
+
+        assert_raises(Shrine::Plugins::DataUri::ParseError) do
+          @shrine.data_uri("data:image/png,content")
+        end
+      end
+
+      it "accepts content within :max_size" do
+        @shrine.plugin :data_uri, max_size: 7
+
+        io = @shrine.data_uri("data:image/png,content")
+        assert_equal "content", io.read
+      end
+
+      it "determines base64 content size from the encoded payload" do
+        @shrine.plugin :data_uri, max_size: 7
+
+        io = @shrine.data_uri("data:image/png;base64,#{Base64.encode64("content")}")
+        assert_equal "content", io.read
+
+        assert_raises(Shrine::Plugins::DataUri::ParseError) do
+          @shrine.data_uri("data:image/png;base64,#{Base64.encode64("content!")}")
+        end
+      end
+
+      it "accounts for percent-encoding when determining content size" do
+        @shrine.plugin :data_uri, max_size: 11
+
+        io = @shrine.data_uri("data:,hello%20world")
+        assert_equal "hello world", io.read
+      end
+
       it "accepts :filename" do
         io = @shrine.data_uri("data:,content", filename: "foo.txt")
         assert_equal "foo.txt", io.original_filename
@@ -212,6 +245,14 @@ describe Shrine::Plugins::DataUri do
         @attacher.assign_data_uri("bla")
 
         assert_equal ["data URI has invalid format"], @attacher.errors
+      end
+
+      it "adds validation error on oversized data URI" do
+        @shrine.plugin :data_uri, max_size: 6
+
+        @attacher.assign_data_uri("data:image/png,content")
+
+        assert_equal ["data URI is too large"], @attacher.errors
       end
 
       it "clears any previous errors" do

--- a/test/plugin/data_uri_test.rb
+++ b/test/plugin/data_uri_test.rb
@@ -123,22 +123,19 @@ describe Shrine::Plugins::DataUri do
         assert_equal 0,  io.size
       end
 
-      it "refuses content larger than :max_size" do
-        @shrine.plugin :data_uri, max_size: 6
-
-        assert_raises(Shrine::Plugins::DataUri::ParseError) do
-          @shrine.data_uri("data:image/png,content")
-        end
-      end
-
-      it "accepts content within :max_size" do
+      it "applies :max_size" do
         @shrine.plugin :data_uri, max_size: 7
 
         io = @shrine.data_uri("data:image/png,content")
         assert_equal "content", io.read
+
+        error = assert_raises(Shrine::Plugins::DataUri::ParseError) do
+          @shrine.data_uri("data:image/png,content!")
+        end
+        assert_equal "data URI is too large", error.message
       end
 
-      it "determines base64 content size from the encoded payload" do
+      it "determines :max_size from the encoded content" do
         @shrine.plugin :data_uri, max_size: 7
 
         io = @shrine.data_uri("data:image/png;base64,#{Base64.encode64("content")}")
@@ -147,13 +144,6 @@ describe Shrine::Plugins::DataUri do
         assert_raises(Shrine::Plugins::DataUri::ParseError) do
           @shrine.data_uri("data:image/png;base64,#{Base64.encode64("content!")}")
         end
-      end
-
-      it "accounts for percent-encoding when determining content size" do
-        @shrine.plugin :data_uri, max_size: 11
-
-        io = @shrine.data_uri("data:,hello%20world")
-        assert_equal "hello world", io.read
       end
 
       it "accepts :filename" do
@@ -245,14 +235,23 @@ describe Shrine::Plugins::DataUri do
         @attacher.assign_data_uri("bla")
 
         assert_equal ["data URI has invalid format"], @attacher.errors
-      end
 
-      it "adds validation error on oversized data URI" do
         @shrine.plugin :data_uri, max_size: 6
-
         @attacher.assign_data_uri("data:image/png,content")
 
         assert_equal ["data URI is too large"], @attacher.errors
+      end
+
+      it "accepts :error_message" do
+        @shrine.plugin :data_uri, error_message: -> (uri) { "invalid data URI: #{uri}" }
+        @attacher.assign_data_uri("bla")
+
+        assert_equal ["invalid data URI: bla"], @attacher.errors
+
+        @shrine.plugin :data_uri, error_message: -> (uri, error) { error.message }
+        @attacher.assign_data_uri("bla")
+
+        assert_equal ["data URI has invalid format"], @attacher.errors
       end
 
       it "clears any previous errors" do


### PR DESCRIPTION
The data_uri plugin currently has no way to limit the size of the uploaded content — the whole payload gets decoded into memory before validations get a chance to run. remote_url has `:max_size` for exactly this, so this PR adds the same option to data_uri.

I'm aware the general recommendation is to cap request body size at the web server, and we do that too. But `client_max_body_size` is one global knob — in our app different uploaders have different limits (20 MB for audio, 30 MB for images), and the only place to express a per-uploader cap is Shrine itself. Without it, a payload that's over the uploader's limit but under the global one still gets fully decoded just to be thrown away by `validate_max_size`.

Following remote_url, `:max_size` is the maximum size of the decoded content. The check runs inside `parse_data_uri`, before `post_match` copies the payload out of the URI — on a 30 MB data URI that copy alone was 30 MB of RSS. The size is computed on the URI itself: exact for base64 (counting alphabet characters, so line-wrapped payloads work too), and the encoded length for percent-encoded content, which decoding can only shrink. Rejecting a 30 MB URI now costs 0 MB and 17 ms.

Oversized content fails with `ParseError`, so the `assign_data_uri` error contract is unchanged. Since `ParseError` now has two causes, `:error_message` also receives the error, the same way remote_url does it.

We've been running this in production as a monkey patch; upstreaming it in case it's useful to others.
